### PR TITLE
Nullable management improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file follows the convention described at
 ### Added
 - lemunozm: added `isSome()`, `isNone()` to `Option`.
 - lemunozm: added `isOk()`, `isErr()` to `Result`.
+- lemunozm: added `Option.from()` and `Option.toNullable()` to make easy conversions with nullable values.
 
 ## [4.1.0] - 2021-03-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the convention described at
 [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [4.2.0] - 2021-03-12
+### Added
+- lemunozm: added `isSome()`, `isNone()` to `Option`.
+- lemunozm: added `isOk()`, `isErr()` to `Result`.
+
 ## [4.1.0] - 2021-03-09
 ### Changed
 - lemunozm: return values added to `match()`, `when()` in `Result`, `Option`.
 
-## [4.0.0] - 2020-03-03
+## [4.0.0] - 2021-03-03
 ### Changed
 - **BREAKING CHANGE:** migrated to null safety and Dart SDK 2.12.
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,18 @@ Result<String, Exception> readFileSync(String name) {
 
 void main() {
   var result = readFileSync('README.md');
+
   result.match((text) {
     print('first 80 characters of file:\n');
     print(text.substring(0, 80));
   }, (err) => print(err));
+
+  // or in a more functional way:
+  final msg = result.when(
+    ok: (text) => 'first 80 characters of file:\n$text.substring(0, 80)',
+    err: (err) => err,
+  );
+  print(msg);
 }
 ```
 

--- a/example/oxidized_example.dart
+++ b/example/oxidized_example.dart
@@ -16,8 +16,8 @@ Future<Result<Future<String>, Exception>> readFile(String name) async {
 void main() async {
   var result = readFileSync('README.md');
 
-  // you can use `is` like so
-  if (result is Err) {
+  // you can check like so (or with `is` keyword against `Err`)
+  if (result.isErr()) {
     print('oh no, unable to read the file!');
   } else {
     print('read the file successfully');

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -22,6 +22,12 @@ abstract class Option<T> extends Equatable {
   /// Create a `None` option with no value.
   factory Option.none() => None();
 
+  /// Returns `true` if the option is a `Some` value.
+  bool isSome();
+
+  /// Returns `true` if the option is a `None` value.
+  bool isNone();
+
   /// Invokes either the `someop` or the `noneop` depending on the option.
   ///
   /// This is an attempt at providing something similar to the Rust `match`
@@ -121,6 +127,12 @@ class Some<T> extends Option<T> {
   bool operator ==(other) => other is Some && other._some == _some;
 
   @override
+  bool isSome() => true;
+
+  @override
+  bool isNone() => false;
+
+  @override
   R match<R>(R Function(T) someop, R Function() noneop) => someop(_some);
 
   @override
@@ -192,6 +204,12 @@ class None<T> extends Option<T> {
 
   @override
   bool operator ==(other) => other is None;
+
+  @override
+  bool isSome() => false;
+
+  @override
+  bool isNone() => true;
 
   @override
   R match<R>(R Function(T) someop, R Function() noneop) => noneop();

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -13,14 +13,24 @@ abstract class Option<T> extends Equatable {
   const Option();
 
   /// Create a `Some` option with the given value.
-  ///
-  /// Passing a `null` value will result in a `None`.
-  factory Option.some(T? v) {
-    return v == null ? None() : Some(v);
-  }
+  factory Option.some(T v) => Some(v);
 
   /// Create a `None` option with no value.
   factory Option.none() => None();
+
+  /// Create a option from a nullable value.
+  ///
+  /// Passing a non-null value will result in a `Some`.
+  /// Passing a `null` value will result in a `None`.
+  factory Option.from(T? v) {
+    return v == null ? None() : Some(v);
+  }
+
+  /// Returns an nullable that represents this optional value.
+  ///
+  /// If Option has Some value, it will return that value.
+  /// If Option has a None value, it will return `null`.
+  T? toNullable();
 
   /// Returns `true` if the option is a `Some` value.
   bool isSome();
@@ -127,6 +137,9 @@ class Some<T> extends Option<T> {
   bool operator ==(other) => other is Some && other._some == _some;
 
   @override
+  T? toNullable() => _some;
+
+  @override
   bool isSome() => true;
 
   @override
@@ -204,6 +217,9 @@ class None<T> extends Option<T> {
 
   @override
   bool operator ==(other) => other is None;
+
+  @override
+  T? toNullable() => null;
 
   @override
   bool isSome() => false;

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -31,6 +31,12 @@ abstract class Result<T, E> extends Equatable {
     }
   }
 
+  /// Returns `true` if the option is a `Ok` value.
+  bool isOk();
+
+  /// Returns `true` if the option is a `Err` value.
+  bool isErr();
+
   /// Invokes either the `okop` or the `errop` depending on the result.
   ///
   /// This is an attempt at providing something similar to the Rust `match`
@@ -140,6 +146,12 @@ class Ok<T, E> extends Result<T, E> {
   bool operator ==(other) => other is Ok && other._ok == _ok;
 
   @override
+  bool isOk() => true;
+
+  @override
+  bool isErr() => false;
+
+  @override
   R match<R>(R Function(T) okop, R Function(E) errop) => okop(_ok);
 
   @override
@@ -219,6 +231,12 @@ class Err<T, E> extends Result<T, E> {
 
   @override
   bool operator ==(other) => other is Err && other._err == _err;
+
+  @override
+  bool isOk() => false;
+
+  @override
+  bool isErr() => true;
 
   @override
   R match<R>(R Function(T) okop, R Function(E) errop) => errop(_err);

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -9,6 +9,8 @@ void main() {
     test('some has a value', () {
       expect(Option.some(1), isA<Some>());
       expect(Some(1), isA<Some>());
+      expect(Some(1).isSome(), isTrue);
+      expect(Some(1).isNone(), isFalse);
     });
 
     test('null some is considered none', () {
@@ -21,6 +23,8 @@ void main() {
       expect(None(), isA<None>());
       expect(None(), equals(None()));
       expect(None() == None(), isTrue);
+      expect(None().isSome(), isFalse);
+      expect(None().isNone(), isTrue);
     });
 
     test('expectations', () {

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -13,11 +13,6 @@ void main() {
       expect(Some(1).isNone(), isFalse);
     });
 
-    test('null some is considered none', () {
-      var option = Option.some(null);
-      expect(option, isA<None>());
-    });
-
     test('none has nothing', () {
       expect(Option.none(), isA<None>());
       expect(None(), isA<None>());
@@ -25,6 +20,16 @@ void main() {
       expect(None() == None(), isTrue);
       expect(None().isSome(), isFalse);
       expect(None().isNone(), isTrue);
+    });
+
+    test('from nullable', () {
+      expect(Option.from(1).isSome(), isTrue);
+      expect(Option.from(null).isNone(), isTrue);
+    });
+
+    test('to nullable', () {
+      expect(Option.from(1).toNullable(), equals(1));
+      expect(Option.from(null).toNullable(), equals(null));
     });
 
     test('expectations', () {

--- a/test/result_test.dart
+++ b/test/result_test.dart
@@ -9,6 +9,8 @@ void main() {
     test('ok is okay', () {
       expect(Result.ok(1), isA<Ok>());
       expect(Ok(1), isA<Ok>());
+      expect(Ok(1).isOk(), isTrue);
+      expect(Ok(1).isErr(), isFalse);
     });
 
     test('null ok is still okay', () {
@@ -20,6 +22,8 @@ void main() {
     test('err is not okay', () {
       expect(Result.err(Exception()), isA<Err>());
       expect(Err(Exception()), isA<Err>());
+      expect(Err(Exception()).isOk(), isFalse);
+      expect(Err(Exception()).isErr(), isTrue);
     });
 
     test('null err is still an error', () {


### PR DESCRIPTION
Rationale: https://github.com/nlfiedler/oxidized/issues/7

This PR adds:
 - `Option.from()` that converts nullable into an option.
 - `Option.toNullable()` that converts an option into a nullable.

This PR goes in second place after: https://github.com/nlfiedler/oxidized/pull/8