### PR TITLE
Option and Result with non nullable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the convention described at
 [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unrealeased]
+
+### Changed
+- kranfix: refactored `Option<T extends Object>` to fix `Result<int?, Exception>.ok(null).ok()`
+- kranfix: refactored `Result<T extends Object, E extends Object>` to fix `Result<int?, Exception>.ok(null)`
+
 ## [4.2.0] - 2021-04-30
 ### Added
 - lemunozm: added `isSome()`, `isNone()` to `Option`.

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -123,9 +123,7 @@ class Some<T extends Object> extends Option<T> {
   final T _some;
 
   /// Create a `Some` option with the given value.
-  Some(v)
-      : assert(v != null),
-        _some = v;
+  Some(v) : _some = v;
 
   @override
   List<Object?> get props => [_some];

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -9,7 +9,7 @@ import './result.dart';
 ///
 /// `Option<T>` is the type used for returning an optional value. It is an
 /// object with a `Some` value, and `None`, representing no value.
-abstract class Option<T> extends Equatable {
+abstract class Option<T extends Object> extends Equatable {
   const Option();
 
   /// Create a `Some` option with the given value.
@@ -69,7 +69,7 @@ abstract class Option<T> extends Equatable {
 
   /// Maps an `Option<T>` to `Option<U>` by applying a function to a contained
   /// `Some` value. Otherwise returns a `None`.
-  Option<U> map<U>(U Function(T) op);
+  Option<U> map<U extends Object>(U Function(T) op);
 
   /// Applies a function to the contained value (if any), or returns the
   /// provided default (if not).
@@ -81,11 +81,11 @@ abstract class Option<T> extends Equatable {
 
   /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Some(v)` to
   /// `Ok(v)` and `None` to `Err(err)`.
-  Result<T, E> okOr<E>(E err);
+  Result<T, E> okOr<E extends Object>(E err);
 
   /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Some(v)` to
   /// `Ok(v)` and `None` to `Err(err())`.
-  Result<T, E> okOrElse<E>(E Function() err);
+  Result<T, E> okOrElse<E extends Object>(E Function() err);
 
   /// Returns `None` if the option is `None`, otherwise calls `predicate` with
   /// the wrapped value and returns:
@@ -119,7 +119,7 @@ abstract class Option<T> extends Equatable {
 /// `Option.some()` factory constructor. The advantage of using the factory
 /// constructor on `Option` is that it will yield a `None` if the passed value
 /// is `null`, which can be helpful.
-class Some<T> extends Option<T> {
+class Some<T extends Object> extends Option<T> {
   final T _some;
 
   /// Create a `Some` option with the given value.
@@ -165,7 +165,7 @@ class Some<T> extends Option<T> {
   T unwrapOrElse(T Function() op) => _some;
 
   @override
-  Option<U> map<U>(U Function(T) op) => Option.some(op(_some));
+  Option<U> map<U extends Object>(U Function(T) op) => Option.some(op(_some));
 
   @override
   U mapOr<U>(U Function(T) op, U opt) => op(_some);
@@ -174,10 +174,10 @@ class Some<T> extends Option<T> {
   U mapOrElse<U>(U Function(T) op, U Function() def) => op(_some);
 
   @override
-  Result<T, E> okOr<E>(E err) => Result.ok(_some);
+  Result<T, E> okOr<E extends Object>(E err) => Result.ok(_some);
 
   @override
-  Result<T, E> okOrElse<E>(E Function() err) => Result.ok(_some);
+  Result<T, E> okOrElse<E extends Object>(E Function() err) => Result.ok(_some);
 
   @override
   Option<T> filter(bool Function(T) predicate) {
@@ -205,7 +205,7 @@ class Some<T> extends Option<T> {
 /// You can construct a `None` using the `None()` constructor or by calling the
 /// `Option.none()` factory constructor. A `None` is also returned when a `null`
 /// is passed to the `Option.some()` factory constructor.
-class None<T> extends Option<T> {
+class None<T extends Object> extends Option<T> {
   /// Create a `None` option with no value.
   const None();
 
@@ -251,7 +251,7 @@ class None<T> extends Option<T> {
   T unwrapOrElse(T Function() op) => op();
 
   @override
-  Option<U> map<U>(U Function(T) op) => Option.none();
+  Option<U> map<U extends Object>(U Function(T) op) => Option.none();
 
   @override
   U mapOr<U>(U Function(T) op, U opt) => opt;
@@ -260,10 +260,11 @@ class None<T> extends Option<T> {
   U mapOrElse<U>(U Function(T) op, U Function() def) => def();
 
   @override
-  Result<T, E> okOr<E>(E err) => Result.err(err);
+  Result<T, E> okOr<E extends Object>(E err) => Result.err(err);
 
   @override
-  Result<T, E> okOrElse<E>(E Function() err) => Result.err(err());
+  Result<T, E> okOrElse<E extends Object>(E Function() err) =>
+      Result.err(err());
 
   @override
   Option<T> filter(bool Function(T) predicate) => Option.none();

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -9,14 +9,14 @@ import './option.dart';
 /// `Result<T, E>` is the type used for returning and propagating errors. It is
 /// an object with an `Ok` value, representing success and containing a value,
 /// and `Err`, representing error and containing an error value.
-abstract class Result<T, E> extends Equatable {
+abstract class Result<T extends Object, E extends Object> extends Equatable {
   Result();
 
   /// Create an `Ok` result with the given value.
-  factory Result.ok(T s) => Ok(s);
+  factory Result.ok(T s) = Ok;
 
   /// Create an `Err` result with the given error.
-  factory Result.err(E err) => Err(err);
+  factory Result.err(E err) = Err;
 
   /// Call the `catching` function and produce a `Result`.
   ///
@@ -54,7 +54,10 @@ abstract class Result<T, E> extends Equatable {
   /// Invoke either the `ok` or the `err` function based on the result.
   ///
   /// This is a combination of the [map()] and [mapErr()] functions.
-  Result<U, F> fold<U, F>(U Function(T) ok, F Function(E) err);
+  Result<U, F> fold<U extends Object, F extends Object>(
+    U Function(T) ok,
+    F Function(E) err,
+  );
 
   /// Converts the `Result` into an `Option` containing the value, if any.
   /// Otherwise returns `None` if the result is an error.
@@ -76,14 +79,14 @@ abstract class Result<T, E> extends Equatable {
 
   /// Maps a `Result<T, E>` to `Result<U, E>` by applying a function to a
   /// contained `Ok` value, leaving an `Err` value untouched.
-  Result<U, E> map<U>(U Function(T) op);
+  Result<U, E> map<U extends Object>(U Function(T) op);
 
   /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to
   /// a contained `Err` value, leaving an `Ok` value untouched.
   ///
   /// This function can be used to pass through a successful result while
   /// handling an error.
-  Result<T, F> mapErr<F>(F Function(E) op);
+  Result<T, F> mapErr<F extends Object>(F Function(E) op);
 
   /// Applies a function to the contained value (if any), or returns the
   /// provided default (if not).
@@ -130,7 +133,7 @@ abstract class Result<T, E> extends Equatable {
 ///
 /// You can create an `Ok` using either the `Ok()` constructor or the
 /// `Result.ok()` factory constructor.
-class Ok<T, E> extends Result<T, E> {
+class Ok<T extends Object, E extends Object> extends Result<T, E> {
   final T _ok;
 
   /// Create an `Ok` result with the given value.
@@ -158,7 +161,11 @@ class Ok<T, E> extends Result<T, E> {
   R when<R>({required R Function(T) ok, required R Function(E) err}) => ok(_ok);
 
   @override
-  Result<U, F> fold<U, F>(U Function(T) ok, F Function(E) err) => Ok(ok(_ok));
+  Result<U, F> fold<U extends Object, F extends Object>(
+    U Function(T) ok,
+    F Function(E) err,
+  ) =>
+      Ok(ok(_ok));
 
   @override
   Option<T> ok() => Option.some(_ok);
@@ -175,10 +182,10 @@ class Ok<T, E> extends Result<T, E> {
   }
 
   @override
-  Result<U, E> map<U>(U Function(T) op) => Ok(op(_ok));
+  Result<U, E> map<U extends Object>(U Function(T) op) => Ok(op(_ok));
 
   @override
-  Result<T, F> mapErr<F>(F Function(E) op) => Ok(_ok);
+  Result<T, F> mapErr<F extends Object>(F Function(E) op) => Ok(_ok);
 
   @override
   U mapOr<U>(U Function(T) op, U opt) => op(_ok);
@@ -217,7 +224,7 @@ class Ok<T, E> extends Result<T, E> {
 ///
 /// You can create an `Err` using either the `Err(E)` constructor or the
 /// `Result.err(E)` factory constructor.
-class Err<T, E> extends Result<T, E> {
+class Err<T extends Object, E extends Object> extends Result<T, E> {
   final E _err;
 
   /// Create an `Err` result with the given error.
@@ -246,7 +253,10 @@ class Err<T, E> extends Result<T, E> {
       err(_err);
 
   @override
-  Result<U, F> fold<U, F>(U Function(T) ok, F Function(E) err) =>
+  Result<U, F> fold<U extends Object, F extends Object>(
+    U Function(T) ok,
+    F Function(E) err,
+  ) =>
       Err(err(_err));
 
   @override
@@ -264,10 +274,10 @@ class Err<T, E> extends Result<T, E> {
   E expectErr(String msg) => _err;
 
   @override
-  Result<U, E> map<U>(U Function(T) op) => Err(_err);
+  Result<U, E> map<U extends Object>(U Function(T) op) => Err(_err);
 
   @override
-  Result<T, F> mapErr<F>(F Function(E) op) => Err(op(_err));
+  Result<T, F> mapErr<F extends Object>(F Function(E) op) => Err(op(_err));
 
   @override
   U mapOr<U>(U Function(T) op, U opt) => opt;
@@ -288,9 +298,7 @@ class Err<T, E> extends Result<T, E> {
   Result<T, E> orElse(Result<T, E> Function(E) op) => op(_err);
 
   @override
-  T unwrap() {
-    throw _err as Object;
-  }
+  T unwrap() => throw _err;
 
   @override
   E unwrapErr() => _err;

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -24,12 +24,12 @@ void main() {
 
     test('from nullable', () {
       expect(Option.from(1).isSome(), isTrue);
-      expect(Option.from(null).isNone(), isTrue);
+      expect(Option<int>.from(null).isNone(), isTrue);
     });
 
     test('to nullable', () {
       expect(Option.from(1).toNullable(), equals(1));
-      expect(Option.from(null).toNullable(), equals(null));
+      expect(Option<int>.from(null).toNullable(), equals(null));
     });
 
     test('expectations', () {

--- a/test/result_test.dart
+++ b/test/result_test.dart
@@ -13,12 +13,6 @@ void main() {
       expect(Ok(1).isErr(), isFalse);
     });
 
-    test('null ok is still okay', () {
-      var result = Result.ok(null);
-      expect(result, isA<Ok>());
-      expect(result, isNot(isA<Err>()));
-    });
-
     test('unit value is an ok unit', () {
       var result = Result.ok(unit);
       expect(result, isA<Ok>());
@@ -31,11 +25,6 @@ void main() {
       expect(Err(Exception()), isA<Err>());
       expect(Err(Exception()).isOk(), isFalse);
       expect(Err(Exception()).isErr(), isTrue);
-    });
-
-    test('null err is still an error', () {
-      expect(Result.err(null), isA<Err>());
-      expect(Err(null), isA<Err>());
     });
 
     test('catching ok values', () {


### PR DESCRIPTION
The following line generates an assertion error;

```
Result<int?, Exception>.ok(null).ok();
```

![](https://cdn.discordapp.com/attachments/787513582975713293/874054817713111060/unknown.png)

This is because the `Some` constructor asserts that the value is different to `null`.  

![](https://cdn.discordapp.com/attachments/787513582975713293/874054927830368326/unknown.png)

This means that `T` in `Some<T>` must be non-null, then it must be defined as following:

```
abstract class Option<T extends Object> { ... }
```

And therefore, Result must be defined as `abstract class Result<T extends Object, E extends Objects>{...} ` to avoid that bad behavior explained above.

In addition, if `Some(null)` would be valid, the constructor `Option.from(null)` never will be able to create an `Some(null)`.  
Another point to consider is that the intention of `Option` is to avoid null and `unit` was also created to avoid `Ok(null)` and `Result<Null, Exception>`.  

![](https://cdn.discordapp.com/attachments/787513582975713293/874055005399830608/unknown.png)

All of these tell us that `Option` and `Result` must not admit `null`s. This PR solve this conceptual issue.