### PR TITLE
Chore/coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 
 # Directory created by dartdoc
 doc/api/
+
+#  coverage
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,38 +5,56 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the convention described at
 [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unrealeased [5.0.1] - 2021-08-20
+
+- kranfix: Full coverage
+
 ## [5.0.0] - 2021-08-11
+
 ### Changed
+
 - **BREAKING CHANGE:** can no longer pass `null` to `Result`. The rectifies the
   inconsistent handling of null values with regards to `Option` and `Result`.
 - kranfix: refactored `Option<T extends Object>` to fix `Result<int?, Exception>.ok(null).ok()`
 - kranfix: refactored `Result<T extends Object, E extends Object>` to fix `Result<int?, Exception>.ok(null)`
 
 ## [4.2.0] - 2021-04-30
+
 ### Added
+
 - lemunozm: added `isSome()`, `isNone()` to `Option`.
 - lemunozm: added `isOk()`, `isErr()` to `Result`.
 - lemunozm: added `Option.from()` and `Option.toNullable()` to make easy conversions with nullable values.
 - Added a `Unit` type that is similar to Rust's `()` type.
 
 ## [4.1.0] - 2021-03-09
+
 ### Changed
+
 - lemunozm: return values added to `match()`, `when()` in `Result`, `Option`.
 
 ## [4.0.0] - 2021-03-03
+
 ### Changed
+
 - **BREAKING CHANGE:** migrated to null safety and Dart SDK 2.12.
 
 ## [3.1.0] - 2020-03-22
+
 ### Added
+
 - Add `fold()` function on `Result` that combines `map()` and `mapErr()`.
 
 ## [3.0.1] - 2020-03-18
+
 ### Changed
+
 - Fix the package description and code formatting.
 
 ## [3.0.0] - 2020-03-18
+
 ### Changed
+
 - **BREAKING CHANGES:** see below for the details.
 - The `Result` "ok" and "error" values are full-fledged classes now.
 - The `Option` "some" and "none" values are full-fledged classes now.
@@ -47,13 +65,19 @@ This file follows the convention described at
 - Both the `Ok` and `Err` subclasses of `Result` allow for null arguments.
 
 ## [2.0.0] - 2020-03-14
+
 ### Added
+
 - Borrowing from `simple_result`, added `when()` as an alternative to `match()`.
+
 ### Changed
+
 - **BREAKING CHANGE:** the various `is` methods are now getters.
 - Extend `Equatable` in both `Option` and `Result`.
 - Override the equals operator (`==`) in both `Option` and `Result`.
 
 ## [1.0.0] - 2020-03-09
+
 ### Added
+
 - Initial version

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -132,9 +132,6 @@ class Some<T extends Object> extends Option<T> {
   bool get stringify => true;
 
   @override
-  bool operator ==(other) => other is Some && other._some == _some;
-
-  @override
   T? toNullable() => _some;
 
   @override
@@ -212,9 +209,6 @@ class None<T extends Object> extends Option<T> {
 
   @override
   bool get stringify => true;
-
-  @override
-  bool operator ==(other) => other is None;
 
   @override
   T? toNullable() => null;

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -123,7 +123,7 @@ class Some<T extends Object> extends Option<T> {
   final T _some;
 
   /// Create a `Some` option with the given value.
-  Some(v) : _some = v;
+  Some(T v) : _some = v;
 
   @override
   List<Object?> get props => [_some];

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -146,9 +146,6 @@ class Ok<T extends Object, E extends Object> extends Result<T, E> {
   bool get stringify => true;
 
   @override
-  bool operator ==(other) => other is Ok && other._ok == _ok;
-
-  @override
   bool isOk() => true;
 
   @override
@@ -235,9 +232,6 @@ class Err<T extends Object, E extends Object> extends Result<T, E> {
 
   @override
   bool get stringify => true;
-
-  @override
-  bool operator ==(other) => other is Err && other._err == _err;
 
   @override
   bool isOk() => false;

--- a/lib/src/unit.dart
+++ b/lib/src/unit.dart
@@ -1,7 +1,6 @@
 //
 // Copyright (c) 2020 Nathan Fiedler
 //
-import 'package:equatable/equatable.dart';
 
 /// The `Unit` type has exactly one value `()`, and is used when there is no
 /// other meaningful value that could be returned for a `Result`.
@@ -9,14 +8,8 @@ import 'package:equatable/equatable.dart';
 /// For instance, returning a "nothing" `Result` would be as simple as
 /// `Result.ok(unit)` and its type would be `Result<Unit, ..>` for whatever type
 /// of error the result represents.
-class Unit extends Equatable {
+class Unit {
   const Unit._internal();
-
-  @override
-  List<Object> get props => [];
-
-  @override
-  bool get stringify => true;
 
   @override
   String toString() => '()';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  equatable: ^2.0.0
+  equatable: ^2.0.3
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -50,6 +50,9 @@ void main() {
     });
 
     test('unwrapping with a default', () {
+      expect(Option.some(5).unwrapOr(2), equals(5));
+      expect(Option.some(5).unwrapOrElse(() => 2), equals(5));
+
       expect(Option.none().unwrapOr(2), equals(2));
       expect(Option.none().unwrapOrElse(() => 2), equals(2));
     });

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -41,7 +41,10 @@ void main() {
       expect(Option.some(2) == Option.some(2), isTrue);
       expect(Option.some(2) == Option.some(3), isFalse);
       expect(Option.none() == Option.none(), isTrue);
-      expect(Option.some(2) == Option.none(), isFalse);
+      expect(Option.some(2) == Option<int>.none(), isFalse);
+
+      expect(Option.some(2) == Option.some(2.0), isFalse);
+      expect(Option<int>.none() == Option<double>.none(), isFalse);
     });
 
     test('unwrapping the present', () {

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -90,6 +90,8 @@ void main() {
       expect(Option.some(5).mapOr((v) => v * 2, 2), equals(10));
       expect(Option.some(5).mapOrElse((v) => v * 2, () => 2), equals(10));
       expect(Option.none().map((v) => fail('oh no')), isA<None>());
+      expect(Option<int>.none().mapOr((v) => fail('oh no'), 2), equals(2));
+      expect(None<int>().mapOrElse((v) => fail('oh no'), () => 2), equals(2));
     });
 
     test('option as a result', () {

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -32,6 +32,11 @@ void main() {
       expect(Option<int>.from(null).toNullable(), equals(null));
     });
 
+    test('to string', () {
+      expect(Some(1).toString(), equals('Some<int>(1)'));
+      expect(None<int>().toString(), equals('None<int>()'));
+    });
+
     test('expectations', () {
       expect(Option.some(2).expect('foo'), equals(2));
       expect(() => Option.none().expect('oh no'), throwsException);

--- a/test/result_test.dart
+++ b/test/result_test.dart
@@ -58,6 +58,23 @@ void main() {
       expect(Result.ok(2), isNot(equals(Result.err(Exception()))));
     });
 
+    test('to string', () {
+      expect(Result.ok(2).toString(), equals('Ok<int, Object>(2)'));
+      expect(
+        Result<int, String>.ok(2).toString(),
+        equals('Ok<int, String>(2)'),
+      );
+
+      expect(
+        Result.err('message').toString(),
+        equals('Err<Object, String>(message)'),
+      );
+      expect(
+        Result<int, String>.err('message').toString(),
+        equals('Err<int, String>(message)'),
+      );
+    });
+
     test('matching results', () {
       var called = 0;
       var returned = Result.ok(3).match((v) {

--- a/test/result_test.dart
+++ b/test/result_test.dart
@@ -166,6 +166,8 @@ void main() {
     });
 
     test('unwrapping with a default', () {
+      expect(Result.ok(5).unwrapOr(2), equals(5));
+      expect(Result.ok(5).unwrapOrElse((e) => fail('oh no')), equals(5));
       expect(Result.err(Exception()).unwrapOr(2), equals(2));
       expect(Result.err(Exception()).unwrapOrElse((e) => 2), equals(2));
     });

--- a/test/result_test.dart
+++ b/test/result_test.dart
@@ -47,9 +47,12 @@ void main() {
 
     test('equal values are equal', () {
       expect(Result.ok(2), equals(Result.ok(2)));
+      expect(Result<int, String>.ok(2), isNot(equals(Result<int, bool>.ok(2))));
       expect(Result.ok(2), isNot(equals(Result.ok(3))));
       var exc = Exception();
       expect(Result.err(exc), equals(Result.err(exc)));
+      expect(
+          Err<int, Exception>(exc), isNot(equals(Err<double, Exception>(exc))));
       // exceptions do not compare equally?
       expect(Result.err(Exception()), isNot(equals(Result.err(Exception()))));
       expect(Result.ok(2), isNot(equals(Result.err(Exception()))));

--- a/test/unit_test.dart
+++ b/test/unit_test.dart
@@ -1,0 +1,19 @@
+import 'package:oxidized/oxidized.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('basic behaviour', () {
+    expect(unit, isA<Unit>());
+    expect(unit.toString(), equals('()'));
+    expect(unit, equals(unit));
+    expect(unit, isNot(equals(2)));
+  });
+
+  test('Result<Unit, T> behaviour', () {
+    expect(Ok(unit).toString(), equals('Ok<Unit, Object>(())'));
+    expect(Ok<Unit, String>(unit).toString(), equals('Ok<Unit, String>(())'));
+
+    expect(Ok(unit), equals(Ok(unit)));
+    expect(Ok<Unit, String>(unit), isNot(equals(Ok<Unit, bool>(unit))));
+  });
+}


### PR DESCRIPTION
*   Removing usage of Equatable for `Unit`. It is not necessary.
*   Adding full coverage for `Option`, `Result` and `Unit`