### PR TITLE
Add missing generics API to Option + Result

### DIFF
--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -95,11 +95,11 @@ abstract class Option<T extends Object> extends Equatable {
   Option<T> filter(bool Function(T) predicate);
 
   /// Returns `None` if the option is `None`, otherwise returns `optb`.
-  Option<T> and(Option<T> optb);
+  Option<U> and<U extends Object>(Option<U> optb);
 
   /// Returns `None` if the option is `None`, otherwise calls `op` with the
   /// wrapped value and returns the result.
-  Option<T> andThen(Option<T> Function(T) op);
+  Option<U> andThen<U extends Object>(Option<U> Function(T) op);
 
   /// Returns the option if it contains a value, otherwise returns `optb`.
   Option<T> or(Option<T> optb);
@@ -180,10 +180,10 @@ class Some<T extends Object> extends Option<T> {
   }
 
   @override
-  Option<T> and(Option<T> optb) => optb;
+  Option<U> and<U extends Object>(Option<U> optb) => optb;
 
   @override
-  Option<T> andThen(Option<T> Function(T) op) => op(_some);
+  Option<U> andThen<U extends Object>(Option<U> Function(T) op) => op(_some);
 
   @override
   Option<T> or(Option<T> optb) => this;
@@ -262,10 +262,11 @@ class None<T extends Object> extends Option<T> {
   Option<T> filter(bool Function(T) predicate) => Option.none();
 
   @override
-  Option<T> and(Option<T> optb) => this;
+  Option<U> and<U extends Object>(Option<U> optb) => Option.none();
 
   @override
-  Option<T> andThen(Option<T> Function(T) op) => this;
+  Option<U> andThen<U extends Object>(Option<U> Function(T) op) =>
+      Option.none();
 
   @override
   Option<T> or(Option<T> optb) => optb;

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2020 Nathan Fiedler
 //
+
 import 'package:equatable/equatable.dart';
 import './option.dart';
 
@@ -97,18 +98,18 @@ abstract class Result<T extends Object, E extends Object> extends Equatable {
   U mapOrElse<U>(U Function(T) op, U Function(E) errOp);
 
   /// Returns `res` if the result is `Ok`, otherwise returns `this`.
-  Result<T, E> and(Result<T, E> res);
+  Result<U, E> and<U extends Object>(Result<U, E> res);
 
   /// Calls `op` with the `Ok` value if the result is `Ok`, otherwise returns
   /// `this`.
-  Result<T, E> andThen(Result<T, E> Function(T) op);
+  Result<U, E> andThen<U extends Object>(Result<U, E> Function(T) op);
 
   /// Returns `res` if the result is an `Err`, otherwise returns `this`.
-  Result<T, E> or(Result<T, E> res);
+  Result<T, F> or<F extends Object>(Result<T, F> res);
 
   /// Calls `op` with the `Err` value if the result is `Err`, otherwise returns
   /// `this`.
-  Result<T, E> orElse(Result<T, E> Function(E) op);
+  Result<T, F> orElse<F extends Object>(Result<T, F> Function(E) op);
 
   /// Unwraps a result, yielding the content of an `Ok`.
   ///
@@ -191,16 +192,17 @@ class Ok<T extends Object, E extends Object> extends Result<T, E> {
   U mapOrElse<U>(U Function(T) op, U Function(E) errOp) => op(_ok);
 
   @override
-  Result<T, E> and(Result<T, E> res) => res;
+  Result<U, E> and<U extends Object>(Result<U, E> res) => res;
 
   @override
-  Result<T, E> andThen(Result<T, E> Function(T) op) => op(_ok);
+  Result<U, E> andThen<U extends Object>(Result<U, E> Function(T) op) =>
+      op(_ok);
 
   @override
-  Result<T, E> or(Result<T, E> res) => this;
+  Result<T, F> or<F extends Object>(Result<T, F> res) => Ok(_ok);
 
   @override
-  Result<T, E> orElse(Result<T, E> Function(E) op) => this;
+  Result<T, F> orElse<F extends Object>(Result<T, F> Function(E) op) => Ok(_ok);
 
   @override
   T unwrap() => _ok;
@@ -280,16 +282,18 @@ class Err<T extends Object, E extends Object> extends Result<T, E> {
   U mapOrElse<U>(U Function(T) op, U Function(E) errOp) => errOp(_err);
 
   @override
-  Result<T, E> and(Result<T, E> res) => this;
+  Result<U, E> and<U extends Object>(Result<U, E> res) => Err(_err);
 
   @override
-  Result<T, E> andThen(Result<T, E> Function(T) op) => this;
+  Result<U, E> andThen<U extends Object>(Result<U, E> Function(T) op) =>
+      Err(_err);
 
   @override
-  Result<T, E> or(Result<T, E> res) => res;
+  Result<T, F> or<F extends Object>(Result<T, F> res) => res;
 
   @override
-  Result<T, E> orElse(Result<T, E> Function(E) op) => op(_err);
+  Result<T, F> orElse<F extends Object>(Result<T, F> Function(E) op) =>
+      op(_err);
 
   @override
   T unwrap() => throw _err;


### PR DESCRIPTION
When dealing with multiple results of different type signatures that are contingent on each other, the lack of generics in these methods produces bloated code when compared to Rust. 

For instance;
```dart
  final everythingOk = Ok(1).and(Ok('foo')).and(Ok(true)).and(Err(false)).isOk();
```
is now possible with this PR.

Thanks!