### PR TITLE
Add async methods to `Result<T, E>`, `Option<T>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the convention described at
 [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [5.2.0] - 2022-02-10
+
+### Added
+
+- rlch: Added async methods to `Option<T>` and `Result<T, E>`.
+- rlch: Added missing type arguments to `Option<T>` and `Result<T, E>`.
+- rlch: Added code coverage for async methods.
+- rlch: Added `OptionFutureRedirector` util to redirect methods called on `Future<Option<T>>`.
+- rlch: Added `ResultFutureRedirector` util to redirect methods called on `Future<Result<T, E>>`.
+
 ## [5.1.0] - 2021-09-20
 
 ### Added

--- a/lib/src/option_utils/option_future_redirector.dart
+++ b/lib/src/option_utils/option_future_redirector.dart
@@ -1,0 +1,170 @@
+part of 'option_utils.dart';
+
+extension OptionFutureRedirector<T extends Object> on Future<Option<T>> {
+  /// Returns an nullable that represents this optional value.
+  ///
+  /// If Option has Some value, it will return that value.
+  /// If Option has a None value, it will return `null`.
+  Future<T?> toNullable() => then((v) => v.toNullable());
+
+  /// Returns `true` if the option is a `Some` value.
+  Future<bool> isSome() => then((v) => v.isSome());
+
+  /// Returns `true` if the option is a `None` value.
+  Future<bool> isNone() => then((v) => v.isNone());
+
+  /// Invokes either the `someop` or the `noneop` depending on the option.
+  ///
+  /// This is an attempt at providing something similar to the Rust `match`
+  /// expression, which makes it easy to handle both cases at once.
+  ///
+  /// See also [when] for another way to achieve the same behavior.
+  Future<R> match<R>(R Function(T) someop, R Function() noneop) =>
+      then((v) => v.match(someop, noneop));
+
+  /// Asynchronously invokes either the `someop` or the `noneop` depending on the option.
+  ///
+  /// This is an attempt at providing something similar to the Rust `match`
+  /// expression, which makes it easy to handle both cases at once.
+  ///
+  /// See also [when] for another way to achieve the same behavior.
+  Future<R> matchAsync<R>(
+    Future<R> Function(T) someop,
+    Future<R> Function() noneop,
+  ) =>
+      then((v) => v.matchAsync(someop, noneop));
+
+  /// Invokes either `some` or `none` depending on the option.
+  ///
+  /// Identical to [match] except that the arguments are named.
+  Future<R> when<R>(
+          {required R Function(T) some, required R Function() none}) =>
+      then((v) => v.when(some: some, none: none));
+
+  /// Asynchronously invokes either `some` or `none` depending on the option.
+  ///
+  /// Identical to [match] except that the arguments are named.
+  Future<R> whenAsync<R>({
+    required Future<R> Function(T) some,
+    required Future<R> Function() none,
+  }) =>
+      then((v) => v.whenAsync(some: some, none: none));
+
+  /// Unwraps an option, yielding the content of a `Some`.
+  ///
+  /// Throws an `Exception` if the value is a `None`, with the passed message.
+  Future<T> expect(String msg) => then((v) => v.expect(msg));
+
+  /// Unwraps an option, yielding the content of a `Some`.
+  ///
+  /// Throws an empty exception if this result is a `None`.
+  Future<T> unwrap() => then((v) => v.unwrap());
+
+  /// Returns the contained value or a default.
+  Future<T> unwrapOr(T opt) => then((v) => v.unwrapOr(opt));
+
+  /// Returns the contained value or computes it from a closure.
+  Future<T> unwrapOrElse(T Function() op) => then((v) => v.unwrapOrElse(op));
+
+  /// Returns the contained value or asynchronously computes it from a closure.
+  Future<T> unwrapOrElseAsync(Future<T> Function() op) =>
+      then((v) => v.unwrapOrElseAsync(op));
+
+  /// Maps an `Option<T>` to `Option<U>` by applying a function to a contained
+  /// `Some` value. Otherwise returns a `None`.
+  Future<Option<U>> map<U extends Object>(U Function(T) op) =>
+      then((v) => v.map(op));
+
+  /// Maps an `Option<T>` to `Option<U>` by applying an asynchronous function to a contained
+  /// `Some` value. Otherwise returns a `None`.
+  Future<Option<U>> mapAsync<U extends Object>(Future<U> Function(T) op) =>
+      then((v) => v.mapAsync(op));
+
+  /// Applies a function to the contained value (if any), or returns the
+  /// provided default (if not).
+  Future<U> mapOr<U>(U Function(T) op, U opt) => then((v) => v.mapOr(op, opt));
+
+  /// Applies an asynchronous function to the contained value (if any), or returns the
+  /// provided default (if not).
+  Future<U> mapOrAsync<U>(Future<U> Function(T) op, U opt) =>
+      then((v) => v.mapOrAsync(op, opt));
+
+  /// Maps an `Option<T>` to `U` by applying a function to a contained `T`
+  /// value, or computes a default (if not).
+  Future<U> mapOrElse<U>(U Function(T) op, U Function() def) =>
+      then((v) => v.mapOrElse(op, def));
+
+  /// Maps an `Option<T>` to `U` by applying an asynchronous function to a contained `T`
+  /// value, or computes a default (if not).
+  Future<U> mapOrElseAsync<U>(
+    Future<U> Function(T) op,
+    Future<U> Function() def,
+  ) =>
+      then((v) => v.mapOrElseAsync(op, def));
+
+  /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Some(v)` to
+  /// `Ok(v)` and `None` to `Err(err)`.
+  Future<Result<T, E>> okOr<E extends Object>(E err) =>
+      then((v) => v.okOr(err));
+
+  /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Some(v)` to
+  /// `Ok(v)` and `None` to `Err(err())`.
+  Future<Result<T, E>> okOrElse<E extends Object>(E Function() err) =>
+      then((v) => v.okOrElse(err));
+
+  /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Some(v)` to
+  /// `Ok(v)` and `None` to `Err(err())`.
+  Future<Result<T, E>> okOrElseAsync<E extends Object>(
+    Future<E> Function() err,
+  ) =>
+      then((v) => v.okOrElseAsync(err));
+
+  /// Returns `None` if the option is `None`, otherwise calls `predicate` with
+  /// the wrapped value and returns:
+  ///
+  /// * `Some(t)` if predicate returns `true` (where `t` is the wrapped value)
+  /// * `None` if predicate returns `false`.
+  Future<Option<T>> filter(bool Function(T) predicate) =>
+      then((v) => v.filter(predicate));
+
+  /// Returns `None` if the option is `None`, otherwise calls `predicate` with
+  /// the wrapped value and returns:
+  ///
+  /// * `Some(t)` if predicate returns `true` (where `t` is the wrapped value)
+  /// * `None` if predicate returns `false`.
+  Future<Option<T>> filterAsync(Future<bool> Function(T) predicate) =>
+      then((v) => v.filterAsync(predicate));
+
+  /// Returns `None` if the option is `None`, otherwise returns `optb`.
+  Future<Option<U>> and<U extends Object>(Option<U> optb) =>
+      then((v) => v.and(optb));
+
+  /// Returns `None` if the option is `None`, otherwise calls `op` with the
+  /// wrapped value and returns the result.
+  Future<Option<U>> andThen<U extends Object>(Option<U> Function(T) op) =>
+      then((v) => v.andThen(op));
+
+  /// Returns `None` if the option is `None`, otherwise asynchronously calls `op` with the
+  /// wrapped value and returns the result.
+  Future<Option<U>> andThenAsync<U extends Object>(
+    Future<Option<U>> Function(T) op,
+  ) =>
+      then((v) => v.andThenAsync(op));
+
+  /// Returns the option if it contains a value, otherwise returns `optb`.
+  Future<Option<T>> or(Option<T> optb) => then((v) => v.or(optb));
+
+  /// Returns the option if it contains a value, otherwise calls `op` and
+  /// returns the result.
+  Future<Option<T>> orElse(Option<T> Function() op) =>
+      then((v) => v.orElse(op));
+
+  /// Returns the option if it contains a value, otherwise asynchronously calls `op` and
+  /// returns the result.
+  Future<Option<T>> orElseAsync(Future<Option<T>> Function() op) =>
+      then((v) => v.orElseAsync(op));
+
+  /// Returns `Some` if exactly one of `this`, `optb` is `Some`, otherwise
+  /// returns `None`.
+  Future<Option<T>> xor(Option<T> optb) => then((v) => v.xor(optb));
+}

--- a/lib/src/option_utils/option_option_flattener.dart
+++ b/lib/src/option_utils/option_option_flattener.dart
@@ -18,3 +18,18 @@ extension OptionOptionFlattener<T extends Object> on Option<Option<T>> {
     );
   }
 }
+
+extension FutureOptionOptionFlattener<T extends Object>
+    on Future<Option<Option<T>>> {
+  /// Flats an option of an option.
+  ///
+  /// ```dart
+  /// Some(Some(1)) => Some(1)
+  /// Some(None()) => None()
+  /// None() => None()
+  /// ```
+  ///
+  /// See also:
+  /// - https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten
+  Future<Option<T>> flatten() => then((v) => v.flatten());
+}

--- a/lib/src/option_utils/option_result_transposer.dart
+++ b/lib/src/option_utils/option_result_transposer.dart
@@ -21,3 +21,19 @@ extension OptionResultTransposer<T extends Object, E extends Object>
     );
   }
 }
+
+extension FutureOptionResultTransposer<T extends Object, E extends Object>
+    on Future<Option<Result<T, E>>> {
+  /// Transposes the result of an option.
+  ///
+  /// ```dart
+  /// Some(Ok(1)) => Ok(Some(1));
+  /// Some(Err('error message')) => Err('error message');
+  /// None() => Ok(None());
+  /// ```
+  ///
+  /// See also https://doc.rust-lang.org/std/option/enum.Option.html#method.transpose
+  Future<Result<Option<T>, E>> transpose() {
+    return then((v) => v.transpose());
+  }
+}

--- a/lib/src/option_utils/option_utils.dart
+++ b/lib/src/option_utils/option_utils.dart
@@ -2,3 +2,4 @@ import 'package:oxidized/oxidized.dart';
 
 part 'option_option_flattener.dart';
 part 'option_result_transposer.dart';
+part 'option_future_redirector.dart';

--- a/lib/src/result_utils/result_future_redirector.dart
+++ b/lib/src/result_utils/result_future_redirector.dart
@@ -1,0 +1,190 @@
+part of 'result_utils.dart';
+
+extension ResultFutureRedirector<T extends Object, E extends Object>
+    on Future<Result<T, E>> {
+  /// Returns `true` if the option is a `Ok` value.
+  Future<bool> isOk() => then((result) => result.isOk());
+
+  /// Returns `true` if the option is a `Err` value.
+  Future<bool> isErr() => then((result) => result.isErr());
+
+  /// Invokes either the `okop` or the `errop` depending on the result.
+  ///
+  /// This is an attempt at providing something similar to the Rust `match`
+  /// expression, which makes it easy to get at the value or error, depending on
+  /// the result.
+  ///
+  /// See also [when] for another way to achieve the same behavior.
+  Future<R> match<R>(R Function(T) okop, R Function(E) errop) =>
+      then((result) => result.match(okop, errop));
+
+  /// Asynchronously invokes either the `okop` or the `errop` depending on the result.
+  ///
+  /// This is an attempt at providing something similar to the Rust `match`
+  /// expression, which makes it easy to get at the value or error, depending on
+  /// the result.
+  ///
+  /// See also [when] for another way to achieve the same behavior.
+  Future<R> matchAsync<R>(
+    Future<R> Function(T) okop,
+    Future<R> Function(E) errop,
+  ) =>
+      then((result) => result.matchAsync(okop, errop));
+
+  /// Invokes either `ok` or `err` depending on the result.
+  ///
+  /// Identical to [match] except that the arguments are named.
+  Future<R> when<R>({required R Function(T) ok, required R Function(E) err}) =>
+      then((result) => result.when(ok: ok, err: err));
+
+  /// Asynchronously invokes either `ok` or `err` depending on the result.
+  ///
+  /// Identical to [match] except that the arguments are named.
+  Future<R> whenAsync<R>({
+    required Future<R> Function(T) ok,
+    required Future<R> Function(E) err,
+  }) =>
+      then((result) => result.whenAsync(ok: ok, err: err));
+
+  /// Invoke either the `ok` or the `err` function based on the result.
+  ///
+  /// This is a combination of the [map()] and [mapErr()] functions.
+  Future<Result<U, F>> fold<U extends Object, F extends Object>(
+    U Function(T) ok,
+    F Function(E) err,
+  ) =>
+      then((result) => result.fold(ok, err));
+
+  /// Asynchronously invoke either the `ok` or the `err` function based on the result.
+  ///
+  /// This is a combination of the [map()] and [mapErr()] functions.
+  Future<Result<U, F>> foldAsync<U extends Object, F extends Object>(
+    Future<U> Function(T) ok,
+    Future<F> Function(E) err,
+  ) =>
+      then((result) => result.foldAsync(ok, err));
+
+  /// Converts the `Result` into an `Option` containing the value, if any.
+  /// Otherwise returns `None` if the result is an error.
+  Future<Option<T>> ok() => then((result) => result.ok());
+
+  /// Converts the `Result` into an `Option` containing the error, if any.
+  /// Otherwise returns `None` if the result is a value.
+  Future<Option<E>> err() => then((result) => result.err());
+
+  /// Unwraps a result, yielding the content of an `Ok`.
+  ///
+  /// Throws an `Exception` if the value is an `Err`, with the passed message.
+  Future<T> expect(String msg) => then((result) => result.expect(msg));
+
+  /// Unwraps a result, yielding the content of an `Err`.
+  ///
+  /// Throws an `Exception` if the value is an `Ok`, with the passed message.
+  Future<E> expectErr(String msg) => then((result) => result.expectErr(msg));
+
+  /// Maps a `Result<T, E>` to `Result<U, E>` by applying a function to a
+  /// contained `Ok` value, leaving an `Err` value untouched.
+  Future<Result<U, E>> map<U extends Object>(U Function(T) op) =>
+      then((result) => result.map(op));
+
+  /// Maps a `Result<T, E>` to `Result<U, E>` by applying an asynchronous function to a
+  /// contained `Ok` value, leaving an `Err` value untouched.
+  Future<Result<U, E>> mapAsync<U extends Object>(Future<U> Function(T) op) =>
+      then((result) => result.mapAsync(op));
+
+  /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to
+  /// a contained `Err` value, leaving an `Ok` value untouched.
+  ///
+  /// This function can be used to pass through a successful result while
+  /// handling an error.
+  Future<Result<T, F>> mapErr<F extends Object>(F Function(E) op) =>
+      then((result) => result.mapErr(op));
+
+  /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to
+  /// a contained `Err` value, leaving an `Ok` value untouched.
+  ///
+  /// This function can be used to pass through a successful result while
+  /// handling an error.
+  Future<Result<T, F>> mapErrAsync<F extends Object>(
+          Future<F> Function(E) op) =>
+      then((result) => result.mapErrAsync(op));
+
+  /// Applies a function to the contained value (if any), or returns the
+  /// provided default (if not).
+  Future<U> mapOr<U>(U Function(T) op, U opt) =>
+      then((result) => result.mapOr(op, opt));
+
+  /// Applies an asynchronous function to the contained value (if any), or returns the
+  /// provided default (if not).
+  Future<U> mapOrAsync<U>(Future<U> Function(T) op, U opt) =>
+      then((result) => result.mapOrAsync(op, opt));
+
+  /// Maps a `Result<T, E>` to `U` by applying a function to a contained
+  /// `Ok` value, or a fallback function to a contained `Err` value.
+  Future<U> mapOrElse<U>(U Function(T) op, U Function(E) errOp) =>
+      then((result) => result.mapOrElse(op, errOp));
+
+  /// Maps a `Result<T, E>` to `U` by applying a function to a contained
+  /// `Ok` value, or a fallback function to a contained `Err` value.
+  Future<U> mapOrElseAsync<U>(
+    Future<U> Function(T) op,
+    Future<U> Function(E) errOp,
+  ) =>
+      then((result) => result.mapOrElseAsync(op, errOp));
+
+  /// Returns `res` if the result is `Ok`, otherwise returns `this`.
+  Future<Result<U, E>> and<U extends Object>(Result<U, E> res) =>
+      then((result) => result.and(res));
+
+  /// Calls `op` with the `Ok` value if the result is `Ok`, otherwise returns
+  /// `this`.
+  Future<Result<U, E>> andThen<U extends Object>(Result<U, E> Function(T) op) =>
+      then((result) => result.andThen(op));
+
+  /// Asynchronously calls `op` with the `Ok` value if the result is `Ok`, otherwise returns
+  /// `this`.
+  Future<Result<U, E>> andThenAsync<U extends Object>(
+    Future<Result<U, E>> Function(T) op,
+  ) =>
+      then((result) => result.andThenAsync(op));
+
+  /// Returns `res` if the result is an `Err`, otherwise returns `this`.
+  Future<Result<T, F>> or<F extends Object>(Result<T, F> res) =>
+      then((result) => result.or(res));
+
+  /// Calls `op` with the `Err` value if the result is `Err`, otherwise returns
+  /// `this`.
+  Future<Result<T, F>> orElse<F extends Object>(Result<T, F> Function(E) op) =>
+      then((result) => result.orElse(op));
+
+  /// Calls `op` with the `Err` value if the result is `Err`, otherwise returns
+  /// `this`.
+  Future<Result<T, F>> orElseAsync<F extends Object>(
+    Future<Result<T, F>> Function(E) op,
+  ) =>
+      then((result) => result.orElseAsync(op));
+
+  /// Unwraps a result, yielding the content of an `Ok`.
+  ///
+  /// Throws the contained error if this result is an `Err`.
+  Future<T> unwrap() => then((result) => result.unwrap());
+
+  /// Unwraps a result, yielding the content of an `Err`.
+  ///
+  /// Throws an exception if the value is an `Ok`, with a custom message
+  /// provided by calling `toString()` on the `Ok`'s value.
+  Future<E> unwrapErr() => then((result) => result.unwrapErr());
+
+  /// Unwraps a result, yielding the content of an `Ok`. Else, it returns `opt`.
+  Future<T> unwrapOr(T opt) => then((result) => result.unwrapOr(opt));
+
+  /// Unwraps a result, yielding the content of an `Ok`. If the value is an
+  /// `Err` then it calls `op` with its value.
+  Future<T> unwrapOrElse(T Function(E) op) =>
+      then((result) => result.unwrapOrElse(op));
+
+  /// Unwraps a result, yielding the content of an `Ok`. If the value is an
+  /// `Err` then it asynchronously calls `op` with its value.
+  Future<T> unwrapOrElseAsync(Future<T> Function(E) op) =>
+      then((result) => result.unwrapOrElseAsync(op));
+}

--- a/lib/src/result_utils/result_option_transposer.dart
+++ b/lib/src/result_utils/result_option_transposer.dart
@@ -22,3 +22,18 @@ extension ResultOptionTransposer<T extends Object, E extends Object>
     );
   }
 }
+
+extension FutureResultOptionTransposer<T extends Object, E extends Object>
+    on Future<Result<Option<T>, E>> {
+  /// Transposes the result to an option.
+  ///
+  /// ```dart
+  /// Ok(None()) => None()
+  /// Ok(Some(val)) => Some(Ok(val))
+  /// Err(err) => Some(Err(err))
+  /// ```
+  ///
+  /// See also:
+  /// - https://doc.rust-lang.org/std/result/enum.Result.html#method.transpose
+  Future<Option<Result<T, E>>> transpose() => then((v) => v.transpose());
+}

--- a/lib/src/result_utils/result_result_flattener.dart
+++ b/lib/src/result_utils/result_result_flattener.dart
@@ -22,3 +22,18 @@ extension ResultResultFlattener<T extends Object, E extends Object>
     );
   }
 }
+
+extension FutureResultResultFlattener<T extends Object, E extends Object>
+    on Future<Result<Result<T, E>, E>> {
+  /// Flattens a [Result<Result<T, E>, E>] into a [Result<T, E>]
+  ///
+  /// ```dart
+  /// Ok(Ok(value)) => Ok(value)
+  /// Ok(Err(error)) => Err(error)
+  /// Err(error) => Err(error)
+  /// ```
+  ///
+  /// See also:
+  /// - https://doc.rust-lang.org/std/result/enum.Result.html#method.flatten
+  Future<Result<T, E>> flatten() => then((v) => v.flatten());
+}

--- a/lib/src/result_utils/result_utils.dart
+++ b/lib/src/result_utils/result_utils.dart
@@ -2,3 +2,4 @@ import 'package:oxidized/oxidized.dart';
 
 part 'result_option_transposer.dart';
 part 'result_result_flattener.dart';
+part 'result_future_redirector.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: oxidized
 description: Definitions of Rust-like types, Option and Result, to promote safer programming.
-version: 5.1.0
+version: 5.2.0
 homepage: https://github.com/nlfiedler/oxidized
 repository: https://github.com/nlfiedler/oxidized.git
 issue_tracker: https://github.com/nlfiedler/oxidized/issues

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -65,6 +65,17 @@ void main() {
       expect(Option.none().unwrapOrElse(() => 2), equals(2));
     });
 
+    test('unwrapping with a default async', () async {
+      expect(
+        await Option.some(5).unwrapOrElseAsync(() async => 2),
+        equals(5),
+      );
+      expect(
+        await Option.none().unwrapOrElseAsync(() async => 2),
+        equals(2),
+      );
+    });
+
     test('matching options', () {
       var called = 0;
       Option.some(3).match((v) {
@@ -73,6 +84,20 @@ void main() {
       }, () => fail('oh no'));
       expect(called, equals(1));
       Option.none().match((v) => fail('oh no'), () => called++);
+      expect(called, equals(2));
+    });
+
+    test('matching options async', () async {
+      var called = 0;
+      await Option.some(3).matchAsync((v) async {
+        expect(v, equals(3));
+        called++;
+      }, () => fail('oh no'));
+      expect(called, equals(1));
+      await Option.none().matchAsync(
+        (v) => fail('oh no'),
+        () async => called++,
+      );
       expect(called, equals(2));
     });
 
@@ -93,6 +118,23 @@ void main() {
       expect(called, equals(2));
     });
 
+    test('when matching options async', () async {
+      var called = 0;
+      await Option.some(3).whenAsync(
+        some: (v) async {
+          expect(v, equals(3));
+          called++;
+        },
+        none: () => fail('oh no'),
+      );
+      expect(called, equals(1));
+      await Option.none().whenAsync(
+        some: (v) => fail('oh no'),
+        none: () async => called++,
+      );
+      expect(called, equals(2));
+    });
+
     test('mapping values', () {
       expect(Option.some(5).map((v) => v * 2).unwrap(), equals(10));
       expect(Option.some(5).mapOr((v) => v * 2, 2), equals(10));
@@ -102,6 +144,36 @@ void main() {
       expect(None<int>().mapOrElse((v) => fail('oh no'), () => 2), equals(2));
     });
 
+    test('mapping values async', () async {
+      expect(
+        await Option.some(5)
+            .mapAsync((v) async => v * 2)
+            .then((v) => v.unwrap()),
+        equals(10),
+      );
+      expect(
+        await Option.some(5).mapOrAsync((v) async => v * 2, 2),
+        equals(10),
+      );
+      expect(
+        await Option.some(5)
+            .mapOrElseAsync((v) async => v * 2, () => Future.value(2)),
+        equals(10),
+      );
+      expect(
+        await Option.none().mapAsync((v) => fail('oh no')),
+        isA<None>(),
+      );
+      expect(
+        await Option<int>.none().mapOrAsync((v) => fail('oh no'), 2),
+        equals(2),
+      );
+      expect(
+        await None<int>().mapOrElseAsync((v) => fail('oh no'), () async => 2),
+        equals(2),
+      );
+    });
+
     test('option as a result', () {
       expect(Option.some(5).okOr(Exception()), isA<Ok>());
       expect(Option.none().okOr(Exception()), isA<Err>());
@@ -109,10 +181,36 @@ void main() {
       expect(Option.none().okOrElse(() => Exception()), isA<Err>());
     });
 
+    test('option as a result async', () async {
+      expect(
+        await Option.some(5).okOrElseAsync(() => fail('oh no')),
+        isA<Ok>(),
+      );
+      expect(
+        await Option.none().okOrElseAsync(() async => Exception()),
+        isA<Err>(),
+      );
+    });
+
     test('filtering options', () {
       expect(Option.some(2).filter((v) => v % 2 == 0), isA<Some>());
       expect(Option.some(3).filter((v) => v % 2 == 0), isA<None>());
       expect(Option.none().filter(((v) => fail('oh no'))), isA<None>());
+    });
+
+    test('filtering options async', () async {
+      expect(
+        await Option.some(2).filterAsync((v) async => v % 2 == 0),
+        isA<Some>(),
+      );
+      expect(
+        await Option.some(3).filterAsync((v) async => v % 2 == 0),
+        isA<None>(),
+      );
+      expect(
+        await Option.none().filterAsync(((v) => fail('oh no'))),
+        isA<None>(),
+      );
     });
 
     test('this and that', () {
@@ -124,12 +222,40 @@ void main() {
       expect(Option.none().andThen(((v) => fail('oh no'))), isA<None>());
     });
 
+    test('this and that', () async {
+      expect(
+        await Option.some(2)
+            .andThenAsync((v) async => Option.some(v * 2))
+            .then((v) => v.unwrap()),
+        equals(4),
+      );
+      expect(
+        await Option.none().andThenAsync(((v) => fail('oh no'))),
+        isA<None>(),
+      );
+    });
+
     test('this or that', () {
       expect(Option.some(2).or(Option.none()), isA<Some>());
       expect(Option.none().or(Option.some(2)), isA<Some>());
       expect(Option.some(2).orElse((() => fail('oh no'))), isA<Some>());
       expect(Option.none().orElse(() => Option.none()), isA<None>());
       expect(Option.none().orElse(() => Option.some(1)), isA<Some>());
+    });
+
+    test('this or that async', () async {
+      expect(
+        await Option.some(2).orElseAsync((() => fail('oh no'))),
+        isA<Some>(),
+      );
+      expect(
+        await Option.none().orElseAsync(() async => Option.none()),
+        isA<None>(),
+      );
+      expect(
+        await Option.none().orElseAsync(() async => Option.some(1)),
+        isA<Some>(),
+      );
     });
 
     test('either this or that', () {


### PR DESCRIPTION
This PR adds asynchronous analogues for each method involving some callback as a parameter. My rationale for not making every method asynchronous is that it ensures the `Future`'s are lazily evaluated; instead of having every `Future` defined in the `Result`/`Option` chain be awaited irrespective of whether or not they're needed for the chain to resolve.

I've included unit tests which covers all of the API introduced, besides the utils which simply call wrap calls on `Future<Option | Result>` with `then((v) => ...)` for convenience. Note that I haven't included unit-tests for this as we'd effectively only be testing `then` + correct passing of parameters. If you'd like coverage on this let me know. 

Closes #11.

---

@nlfiedler,
On another note, I'm using this package almost everyday within my company's Flutter code-base. If you're looking for another maintainer I would be happy to help out :)
Thanks for the great package.