### PR TITLE
fix: typo in OptionLogicMixin

### DIFF
--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -21,7 +21,7 @@ abstract class Option<T extends Object> extends OptionBase<T>
         OptionUnwrapMixin<T>,
         OptionMatchMixin<T>,
         OptionMapFilterMixin<T>,
-        OptionLoginMixin<T>,
+        OptionLogicMixin<T>,
         OptionToResultMixin<T> {
   /// Create a [Some] option with the given value.
   const factory Option.some(T v) = Some;

--- a/lib/src/option/option_logic_mixin.dart
+++ b/lib/src/option/option_logic_mixin.dart
@@ -1,7 +1,7 @@
 part of '../option.dart';
 
 /// Methods like and, or, xor
-mixin OptionLoginMixin<T extends Object> on OptionBase<T> {
+mixin OptionLogicMixin<T extends Object> on OptionBase<T> {
   /// Returns [None] if the option is [None], otherwise returns `optb`.
   Option<U> and<U extends Object>(Option<U> optb) {
     return isSome() ? optb : None<U>();


### PR DESCRIPTION
Fix typo: `OptionLoginMixin` to `OptionLogicMixin`