### PR TITLE
Chore/ok unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the convention described at
 [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [5.2.1] - 2022-04-22
+## [5.3.0] - 2022-04-22
 
 - kranfix: Replaced `pedantic` (deprecated) by `very_goog_analysis`.
 - kranfix: Refactored `Option` into many mixins.
 - kranfix: Better implementation for `Option` async methods.
+- kranfix: `Ok.unit` and `Err.unit` static methods
 
 ## [5.2.0] - 2022-02-10
 

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -4,6 +4,7 @@
 
 import 'package:equatable/equatable.dart';
 import 'package:oxidized/src/option.dart';
+import 'package:oxidized/src/unit.dart';
 
 /// Result is a type that represents either success (`Ok`) or failure (`Err`).
 ///
@@ -355,6 +356,9 @@ class Ok<T extends Object, E extends Object> extends Result<T, E> {
     required Future<R> Function(E) err,
   }) =>
       ok(_ok);
+
+  /// Returns a new [Ok]<[Unit], E>
+  static Ok<Unit, E> unit<E extends Object>() => Ok<Unit, E>(Unit.unit);
 }
 
 /// An `Err<T, E>` is a `Result` that represents a failure.
@@ -504,6 +508,9 @@ class Err<T extends Object, E extends Object> extends Result<T, E> {
     required Future<R> Function(E) err,
   }) =>
       err(_err);
+
+  /// Returns a new [Err]<[Unit], E>
+  static Err<Unit, E> unit<E extends Object>(E error) => Err<Unit, E>(error);
 }
 
 /// {@template oxidized.ResultUnwrapException}

--- a/lib/src/unit.dart
+++ b/lib/src/unit.dart
@@ -13,7 +13,10 @@ class Unit {
 
   @override
   String toString() => '()';
+
+  /// The one instance of `Unit`.
+  static const Unit unit = Unit._internal();
 }
 
 /// The one instance of `Unit`.
-const Unit unit = Unit._internal();
+const Unit unit = Unit.unit;

--- a/test/result_test.dart
+++ b/test/result_test.dart
@@ -356,4 +356,14 @@ void main() {
       );
     });
   });
+
+  group('Result<Unit, E>', () {
+    test('Ok.unit', () {
+      expect(Ok.unit<String>().unwrap(), equals(Unit.unit));
+    });
+
+    test('Ok.unit', () {
+      expect(Err.unit<String>('message').unwrapErr(), equals('message'));
+    });
+  });
 }


### PR DESCRIPTION
*   \`Ok.unit\<E extends Object>\`
*   \`Err.unit\<E extends Object>\`
*   tests