### PR TITLE
Fix possible invalid casting in catch block

### DIFF
--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -28,8 +28,8 @@ abstract class Result<T extends Object, E extends Object> extends Equatable {
   factory Result.of(T Function() catching) {
     try {
       return Ok(catching());
-    } catch (e) {
-      return Err(e as E);
+    } on E catch (e) {
+      return Err(e);
     }
   }
 
@@ -42,8 +42,8 @@ abstract class Result<T extends Object, E extends Object> extends Equatable {
   ) async {
     try {
       return Ok(await catching());
-    } catch (e) {
-      return Err(e as E);
+    } on E catch (e) {
+      return Err(e);
     }
   }
 


### PR DESCRIPTION
Catching `on` the specific error removes the often invalid cast, which throws type errors instead of the underlying error that occurred. While this is meant to catch all errors, often it just leads to confusion