### PR TITLE
Add new dart pattern match support

### DIFF
--- a/lib/oxidized.dart
+++ b/lib/oxidized.dart
@@ -91,9 +91,22 @@
 /// package.
 library oxidized;
 
+import 'package:oxidized/src/result.dart';
+
 export 'src/option.dart' show Option, Some, None, OptionUnwrapException;
 export 'src/option_async_utils/option_async_utils.dart';
 export 'src/option_utils/option_utils.dart';
 export 'src/result.dart';
 export 'src/result_utils/result_utils.dart';
 export 'src/unit.dart';
+
+Result<int, Exception> test() {
+  return const Ok(1);
+}
+
+void main() {
+  final value = switch (test()) {
+    Ok(value: final x) => x,
+    Err(err: final e) => 0,
+  };
+}

--- a/lib/oxidized.dart
+++ b/lib/oxidized.dart
@@ -91,22 +91,9 @@
 /// package.
 library oxidized;
 
-import 'package:oxidized/src/result.dart';
-
 export 'src/option.dart' show Option, Some, None, OptionUnwrapException;
 export 'src/option_async_utils/option_async_utils.dart';
 export 'src/option_utils/option_utils.dart';
 export 'src/result.dart';
 export 'src/result_utils/result_utils.dart';
 export 'src/unit.dart';
-
-Result<int, Exception> test() {
-  return const Ok(1);
-}
-
-void main() {
-  final value = switch (test()) {
-    Ok(value: final x) => x,
-    Err(err: final e) => 0,
-  };
-}

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -16,7 +16,7 @@ part 'option/option_unwrap_mixin.dart';
 ///
 /// [Option<T>] is the type used for returning an optional value. It is an
 /// object with a [Some] value, and [None], representing no value.
-abstract class Option<T extends Object> extends OptionBase<T>
+sealed class Option<T extends Object> extends OptionBase<T>
     with
         OptionUnwrapMixin<T>,
         OptionMatchMixin<T>,
@@ -53,6 +53,9 @@ class Some<T extends Object> extends Option<T> {
         super._();
 
   final T _some;
+
+  /// Wrapped value.
+  T get some => _some;
 
   @override
   List<Object?> get props => [_some];

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -11,7 +11,7 @@ import 'package:oxidized/src/unit.dart';
 /// `Result<T, E>` is the type used for returning and propagating errors. It is
 /// an object with an `Ok` value, representing success and containing a value,
 /// and `Err`, representing error and containing an error value.
-abstract class Result<T extends Object, E extends Object> extends Equatable {
+sealed class Result<T extends Object, E extends Object> extends Equatable {
   const Result._();
 
   /// Create an `Ok` result with the given value.
@@ -225,6 +225,9 @@ class Ok<T extends Object, E extends Object> extends Result<T, E> {
 
   final T _ok;
 
+  /// Wrapped value.
+  T get value => _ok;
+
   @override
   List<Object?> get props => [_ok];
 
@@ -372,6 +375,9 @@ class Err<T extends Object, E extends Object> extends Result<T, E> {
         super._();
 
   final E _err;
+
+  /// Wrapped error.
+  E get error => _err;
 
   @override
   List<Object?> get props => [_err];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/nlfiedler/oxidized.git
 issue_tracker: https://github.com/nlfiedler/oxidized/issues
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=3.0.0"
 
 dependencies:
   equatable: ^2.0.3


### PR DESCRIPTION
Update the lib to support new dart features for patter match with exhaustive checking

```dart
final value = switch(result) {
  Ok(value: final x)  => x,
  Err(error: final e )  => 0,
}

if (result case Ok(value: final x)) {
  // use x
}
``` 