### PR TITLE
New experimental functions for enabling the use of one-liner expressions.

### DIFF
--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -62,6 +62,14 @@ sealed class Result<T extends Object, E extends Object> extends Equatable {
   /// See also [when] for another way to achieve the same behavior.
   R match<R>(R Function(T) okop, R Function(E) errop);
 
+ /// Invokes the `okop` if the result is `Ok`, otherwise does nothing.
+  void matchOk(void Function(T) okop) =>
+      this is Ok<T, E> ? okop((this as Ok<T, E>).value) : null;
+
+  /// Invokes the `errop` if the result is `Err`, otherwise does nothing.
+  void matchErr(void Function(E) errop) =>
+      this is Err<T, E> ? errop((this as Err<T, E>).error) : null;
+
   /// Asynchronously invokes either the `okop` or the `errop` depending on
   /// the result.
   ///
@@ -194,6 +202,12 @@ sealed class Result<T extends Object, E extends Object> extends Equatable {
   ///
   /// Throws the contained error if this result is an `Err`.
   T unwrap();
+
+  /// Unwraps a result, yielding the content of an `Ok`.
+  ///
+  /// If the value is an `Err`, returns `null` instead of throwing an exception.
+  T? unwrapOrNull() => (this is Ok<T, E>) ? (this as Ok<T, E>).value : null;
+
 
   /// Unwraps a result, yielding the content of an `Err`.
   ///
@@ -446,7 +460,7 @@ class Err<T extends Object, E extends Object> extends Result<T, E> {
       op(_err);
 
   @override
-  T unwrap() => throw ResultUnwrapException<T, E>();
+  T unwrap() => throw ResultUnwrapException<T, E>(_err.toString());
 
   @override
   E unwrapErr() => _err;

--- a/lib/src/result_utils/result_future_redirector.dart
+++ b/lib/src/result_utils/result_future_redirector.dart
@@ -19,6 +19,20 @@ extension ResultFutureRedirector<T extends Object, E extends Object>
   Future<R> match<R>(R Function(T) okop, R Function(E) errop) =>
       then((result) => result.match(okop, errop));
 
+  /// Invokes the `okop` if the result is `Ok`, otherwise does nothing.
+  Future<void> matchOk(void Function(T) okop) => then((result) {
+    if (result.isOk()) {
+      okop(result.unwrap());
+    }
+  });
+
+  /// Invokes the `errop` if the result is `Err`, otherwise does nothing.
+  Future<void> matchErr(void Function(E) errop) => then((result) {
+    if (result.isErr()) {
+      errop(result.unwrapErr());
+    }
+  });
+
   /// Asynchronously invokes either the `okop` or the `errop` depending on
   /// the result.
   ///
@@ -173,6 +187,11 @@ extension ResultFutureRedirector<T extends Object, E extends Object>
   ///
   /// Throws the contained error if this result is an `Err`.
   Future<T> unwrap() => then((result) => result.unwrap());
+
+  /// Unwraps a result, yielding the content of an `Ok`.
+  ///
+  /// If the value is an `Err`, returns `null` instead of throwing an exception.
+  Future<T?> unwrapOrNull() => then((result) => result.isOk() ? result.unwrap() : null);
 
   /// Unwraps a result, yielding the content of an `Err`.
   ///


### PR DESCRIPTION
* Attempt to implement the functions matchOk, matchErr, and unwrapOrNull.
* The unwrap function now contains the original error message in case of an Err.