### PR TITLE
Allow nullable values in `Some` and `Ok`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the convention described at
 [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unrealeased]
+### Changed
+- JonasWanke: allow nullable values in `Some` and `Ok`
+
 ## [6.1.0] - 2023-07-15
 ### Added
 - amaxcz: add `matchOk()`, `matchErr()`, and `unwrapOrNull()` functions to `Result`

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -16,7 +16,7 @@ part 'option/option_unwrap_mixin.dart';
 ///
 /// [Option<T>] is the type used for returning an optional value. It is an
 /// object with a [Some] value, and [None], representing no value.
-sealed class Option<T extends Object> extends OptionBase<T>
+sealed class Option<T> extends OptionBase<T>
     with
         OptionUnwrapMixin<T>,
         OptionMatchMixin<T>,
@@ -46,7 +46,7 @@ sealed class Option<T extends Object> extends OptionBase<T>
 /// `Option.some()` factory constructor. The advantage of using the factory
 /// constructor on `Option` is that it will yield a `None` if the passed value
 /// is `null`, which can be helpful.
-class Some<T extends Object> extends Option<T> {
+class Some<T> extends Option<T> {
   /// Create a `Some` option with the given value.
   const Some(T v)
       : _some = v,
@@ -69,7 +69,7 @@ class Some<T extends Object> extends Option<T> {
 /// You can construct a `None` using the `None()` constructor or by calling the
 /// `Option.none()` factory constructor. A `None` is also returned when a `null`
 /// is passed to the `Option.some()` factory constructor.
-class None<T extends Object> extends Option<T> {
+class None<T> extends Option<T> {
   /// Create a `None` option with no value.
   const None() : super._();
 

--- a/lib/src/option/option_base.dart
+++ b/lib/src/option/option_base.dart
@@ -2,7 +2,7 @@ part of '../option.dart';
 
 /// [OptionBase] is the base for [Option] class.
 /// It must not be used directly.
-abstract class OptionBase<T extends Object> extends Equatable {
+abstract class OptionBase<T> extends Equatable {
   const OptionBase._();
 
   @override

--- a/lib/src/option/option_base.dart
+++ b/lib/src/option/option_base.dart
@@ -10,13 +10,13 @@ abstract class OptionBase<T> extends Equatable {
 
   /// Returns an nullable that represents this optional value.
   ///
-  /// If Option has Some value, it will return that value.
-  /// If Option has a None value, it will return `null`.
+  /// If Option has [Some] value, it will return that value.
+  /// If Option has a [None] value, it will return `null`.
   T? toNullable();
 
-  /// Returns `true` if the option is a `Some` value.
+  /// Returns `true` if the option is a [Some] value.
   bool isSome() => this is Some;
 
-  /// Returns `true` if the option is a `None` value.
+  /// Returns `true` if the option is a [None] value.
   bool isNone() => this is None;
 }

--- a/lib/src/option/option_logic_mixin.dart
+++ b/lib/src/option/option_logic_mixin.dart
@@ -1,17 +1,16 @@
 part of '../option.dart';
 
 /// Methods like and, or, xor
-mixin OptionLogicMixin<T extends Object> on OptionBase<T> {
+mixin OptionLogicMixin<T> on OptionBase<T> {
   /// Returns [None] if the option is [None], otherwise returns `optb`.
-  Option<U> and<U extends Object>(Option<U> optb) {
+  Option<U> and<U>(Option<U> optb) {
     return isSome() ? optb : None<U>();
   }
 
   /// Returns `None` if the option is `None`, otherwise calls `op` with the
   /// wrapped value and returns the result.
-  Option<U> andThen<U extends Object>(Option<U> Function(T) op) {
-    final val = toNullable();
-    return val != null ? op(val) : None<U>();
+  Option<U> andThen<U>(Option<U> Function(T) op) {
+    return isSome() ? op((this as Some<T>).some) : None<U>();
   }
 
   /// Returns the option if it contains a value, otherwise returns `optb`.

--- a/lib/src/option/option_logic_mixin.dart
+++ b/lib/src/option/option_logic_mixin.dart
@@ -7,25 +7,25 @@ mixin OptionLogicMixin<T> on OptionBase<T> {
     return isSome() ? optb : None<U>();
   }
 
-  /// Returns `None` if the option is `None`, otherwise calls `op` with the
+  /// Returns [None] if the option is [None], otherwise calls `op` with the
   /// wrapped value and returns the result.
   Option<U> andThen<U>(Option<U> Function(T) op) {
     return isSome() ? op((this as Some<T>).some) : None<U>();
   }
 
-  /// Returns the option if it contains a value, otherwise returns `optb`.
+  /// Returns the option if it is [Some], otherwise returns `optb`.
   Option<T> or(Option<T> optb) {
     return isSome() ? this as Some<T> : optb;
   }
 
-  /// Returns the option if it contains a value, otherwise calls `op` and
-  /// returns the result.
+  /// Returns the option if it is [Some], otherwise calls `op` and returns the
+  /// result.
   Option<T> orElse(Option<T> Function() op) {
     return isSome() ? this as Some<T> : op();
   }
 
-  /// Returns `Some` if exactly one of `this`, `optb` is `Some`, otherwise
-  /// returns `None`.
+  /// Returns [Some] if exactly one of `this`, `optb` is [Some], otherwise
+  /// returns [None].
   Option<T> xor(Option<T> optb) {
     if (this is None) return optb;
     if (optb is None) return this as Option<T>;

--- a/lib/src/option/option_map_filter_mixin.dart
+++ b/lib/src/option/option_map_filter_mixin.dart
@@ -3,7 +3,7 @@ part of '../option.dart';
 //// Map and filter methods for [Option]
 mixin OptionMapFilterMixin<T> on OptionBase<T> {
   /// Maps an `Option<T>` to `Option<U>` by applying a function to a contained
-  /// `Some` value. Otherwise returns a `None`.
+  /// [Some] value. Otherwise returns a [None].
   Option<U> map<U>(U Function(T) op) {
     if (this case Some(:final some)) {
       return Some(op(some));
@@ -12,8 +12,8 @@ mixin OptionMapFilterMixin<T> on OptionBase<T> {
     }
   }
 
-  /// Applies a function to the contained value (if any), or returns the
-  /// provided default (if not).
+  /// Applies a function to the value (if this is [Some]), or returns the
+  /// provided default (if this is [None]).
   U mapOr<U>(U Function(T) op, U opt) {
     if (this case Some(:final some)) {
       return op(some);
@@ -32,7 +32,7 @@ mixin OptionMapFilterMixin<T> on OptionBase<T> {
     }
   }
 
-  /// Returns `None` if the option is `None`, otherwise calls `predicate` with
+  /// Returns [None] if the option is [None], otherwise calls `predicate` with
   /// the wrapped value and returns:
   ///
   /// * `Some(t)` if predicate returns `true` (where `t` is the wrapped value)

--- a/lib/src/option/option_map_filter_mixin.dart
+++ b/lib/src/option/option_map_filter_mixin.dart
@@ -1,13 +1,12 @@
 part of '../option.dart';
 
 //// Map and filter methods for [Option]
-mixin OptionMapFilterMixin<T extends Object> on OptionBase<T> {
+mixin OptionMapFilterMixin<T> on OptionBase<T> {
   /// Maps an `Option<T>` to `Option<U>` by applying a function to a contained
   /// `Some` value. Otherwise returns a `None`.
-  Option<U> map<U extends Object>(U Function(T) op) {
-    final val = toNullable();
-    if (val != null) {
-      return Some(op(val));
+  Option<U> map<U>(U Function(T) op) {
+    if (this case Some(:final some)) {
+      return Some(op(some));
     } else {
       return None<U>();
     }
@@ -16,9 +15,8 @@ mixin OptionMapFilterMixin<T extends Object> on OptionBase<T> {
   /// Applies a function to the contained value (if any), or returns the
   /// provided default (if not).
   U mapOr<U>(U Function(T) op, U opt) {
-    final val = toNullable();
-    if (val != null) {
-      return op(val);
+    if (this case Some(:final some)) {
+      return op(some);
     } else {
       return opt;
     }
@@ -27,9 +25,8 @@ mixin OptionMapFilterMixin<T extends Object> on OptionBase<T> {
   /// Maps an `Option<T>` to `U` by applying a function to a contained `T`
   /// value, or computes a default (if not).
   U mapOrElse<U>(U Function(T) op, U Function() def) {
-    final val = toNullable();
-    if (val != null) {
-      return op(val);
+    if (this case Some(:final some)) {
+      return op(some);
     } else {
       return def();
     }
@@ -41,11 +38,11 @@ mixin OptionMapFilterMixin<T extends Object> on OptionBase<T> {
   /// * `Some(t)` if predicate returns `true` (where `t` is the wrapped value)
   /// * `None` if predicate returns `false`.
   Option<T> filter(bool Function(T) predicate) {
-    final val = toNullable();
-    if (val != null && predicate(val)) {
-      return Some(val);
-    } else {
-      return None<T>();
+    if (this case Some(:final some)) {
+      if (predicate(some)) {
+        return Some(some);
+      }
     }
+    return None<T>();
   }
 }

--- a/lib/src/option/option_match_mixin.dart
+++ b/lib/src/option/option_match_mixin.dart
@@ -1,7 +1,7 @@
 part of '../option.dart';
 
 ///
-mixin OptionMatchMixin<T extends Object> on OptionBase<T> {
+mixin OptionMatchMixin<T> on OptionBase<T> {
   /// Invokes either the `someop` or the `noneop` depending on the option.
   ///
   /// This is an attempt at providing something similar to the Rust `match`
@@ -9,9 +9,8 @@ mixin OptionMatchMixin<T extends Object> on OptionBase<T> {
   ///
   /// See also [when] for another way to achieve the same behavior.
   R match<R>(R Function(T) someop, R Function() noneop) {
-    final val = toNullable();
-    if (val != null) {
-      return someop(val);
+    if (this case Some(:final some)) {
+      return someop(some);
     } else {
       return noneop();
     }

--- a/lib/src/option/option_to_result_mixin.dart
+++ b/lib/src/option/option_to_result_mixin.dart
@@ -1,18 +1,24 @@
 part of '../option.dart';
 
-/// Methods like and, or, xor
-mixin OptionToResultMixin<T extends Object> on OptionBase<T> {
+///
+mixin OptionToResultMixin<T> on OptionBase<T> {
   /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Some(v)` to
   /// `Ok(v)` and `None` to `Err(err)`.
   Result<T, E> okOr<E extends Object>(E err) {
-    final val = toNullable();
-    return val != null ? Result.ok(val) : Result.err(err);
+    if (this case Some(:final some)) {
+      return Result.ok(some);
+    } else {
+      return Result.err(err);
+    }
   }
 
   /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Some(v)` to
   /// `Ok(v)` and `None` to `Err(err())`.
   Result<T, E> okOrElse<E extends Object>(E Function() err) {
-    final val = toNullable();
-    return val != null ? Result.ok(val) : Result.err(err());
+    if (this case Some(:final some)) {
+      return Result.ok(some);
+    } else {
+      return Result.err(err());
+    }
   }
 }

--- a/lib/src/option/option_unwrap_mixin.dart
+++ b/lib/src/option/option_unwrap_mixin.dart
@@ -2,9 +2,10 @@ part of '../option.dart';
 
 /// Methods por `unwrap` or `expect` for [Option]
 mixin OptionUnwrapMixin<T> on OptionBase<T> {
-  /// Unwraps an option, yielding the content of a `Some`.
+  /// Unwraps an option, yielding the content of a [Some].
   ///
-  /// Throws an `Exception` if the value is a `None`, with the passed message.
+  /// Throws an [OptionUnwrapException] if the value is a [None], with the
+  /// passed message.
   T expect(String msg) {
     if (this case Some(:final some)) {
       return some;
@@ -13,9 +14,9 @@ mixin OptionUnwrapMixin<T> on OptionBase<T> {
     }
   }
 
-  /// Unwraps an option, yielding the content of a `Some`.
+  /// Unwraps an option, yielding the content of a [Some].
   ///
-  /// Throws an empty exception if this result is a `None`.
+  /// Throws an empty [OptionUnwrapException] if this result is a [None].
   T unwrap() {
     if (this case Some(:final some)) {
       return some;

--- a/lib/src/option/option_unwrap_mixin.dart
+++ b/lib/src/option/option_unwrap_mixin.dart
@@ -1,22 +1,40 @@
 part of '../option.dart';
 
 /// Methods por `unwrap` or `expect` for [Option]
-mixin OptionUnwrapMixin<T extends Object> on OptionBase<T> {
+mixin OptionUnwrapMixin<T> on OptionBase<T> {
   /// Unwraps an option, yielding the content of a `Some`.
   ///
   /// Throws an `Exception` if the value is a `None`, with the passed message.
-  T expect(String msg) => toNullable() ?? (throw OptionUnwrapException<T>(msg));
+  T expect(String msg) {
+    if (this case Some(:final some)) {
+      return some;
+    } else {
+      throw OptionUnwrapException<T>(msg);
+    }
+  }
 
   /// Unwraps an option, yielding the content of a `Some`.
   ///
   /// Throws an empty exception if this result is a `None`.
-  T unwrap() => toNullable() ?? (throw OptionUnwrapException<T>());
+  T unwrap() {
+    if (this case Some(:final some)) {
+      return some;
+    } else {
+      throw OptionUnwrapException<T>();
+    }
+  }
 
   /// Returns the contained value or a default.
-  T unwrapOr(T opt) => toNullable() ?? opt;
+  T unwrapOr(T opt) => unwrapOrElse(() => opt);
 
   /// Returns the contained value or computes it from a closure.
-  T unwrapOrElse(T Function() op) => toNullable() ?? op();
+  T unwrapOrElse(T Function() op) {
+    if (this case Some(:final some)) {
+      return some;
+    } else {
+      return op();
+    }
+  }
 }
 
 /// {@template oxidized.OptionUnwrapException}

--- a/lib/src/option_async_utils/option_logic_async_extension.dart
+++ b/lib/src/option_async_utils/option_logic_async_extension.dart
@@ -1,10 +1,10 @@
 part of 'option_async_utils.dart';
 
 /// Async method like and, or, xor
-extension OptionLoginAsyncExtension<T extends Object> on FutureOr<Option<T>> {
+extension OptionLoginAsyncExtension<T> on FutureOr<Option<T>> {
   /// Returns `None` if the option is `None`, otherwise asynchronously calls
   /// `op` with the wrapped value and returns the result.
-  Future<Option<U>> andThenAsync<U extends Object>(
+  Future<Option<U>> andThenAsync<U>(
     FutureOr<Option<U>> Function(T) op,
   ) {
     return Future.value(this).then((option) => option.match(op, None.new));

--- a/lib/src/option_async_utils/option_map_filter_async_extension.dart
+++ b/lib/src/option_async_utils/option_map_filter_async_extension.dart
@@ -3,7 +3,7 @@ part of 'option_async_utils.dart';
 /// Collection of method for async map and filter in a [Option]
 extension OptionMapFilterAsyncX<T> on FutureOr<Option<T>> {
   /// Maps an `Option<T>` to `Option<U>` by applying an asynchronous function
-  /// to a contained `Some` value. Otherwise returns a `None`.
+  /// to a contained [Some] value. Otherwise returns a [None].
   Future<Option<U>> mapAsync<U>(FutureOr<U> Function(T) op) {
     return Future.value(this).then((option) {
       if (this case Some(:final some)) {
@@ -35,7 +35,7 @@ extension OptionMapFilterAsyncX<T> on FutureOr<Option<T>> {
     return Future.value(this).then((option) => option.mapOrElse(op, def));
   }
 
-  /// Returns `None` if the option is `None`, otherwise calls `predicate` with
+  /// Returns [None] if the option is [None], otherwise calls `predicate` with
   /// the wrapped value and returns:
   ///
   /// * `Some(t)` if predicate returns `true` (where `t` is the wrapped value)

--- a/lib/src/option_async_utils/option_map_filter_async_extension.dart
+++ b/lib/src/option_async_utils/option_map_filter_async_extension.dart
@@ -1,14 +1,13 @@
 part of 'option_async_utils.dart';
 
 /// Collection of method for async map and filter in a [Option]
-extension OptionMapFilterAsyncX<T extends Object> on FutureOr<Option<T>> {
+extension OptionMapFilterAsyncX<T> on FutureOr<Option<T>> {
   /// Maps an `Option<T>` to `Option<U>` by applying an asynchronous function
   /// to a contained `Some` value. Otherwise returns a `None`.
-  Future<Option<U>> mapAsync<U extends Object>(FutureOr<U> Function(T) op) {
+  Future<Option<U>> mapAsync<U>(FutureOr<U> Function(T) op) {
     return Future.value(this).then((option) {
-      final val = option.toNullable();
-      if (val != null) {
-        return Future.value(op(val)).then(Some.new);
+      if (this case Some(:final some)) {
+        return Future.value(op(some)).then(Some.new);
       } else {
         return None<U>();
       }
@@ -19,8 +18,11 @@ extension OptionMapFilterAsyncX<T extends Object> on FutureOr<Option<T>> {
   /// returns the provided default (if not).
   Future<U> mapOrAsync<U>(FutureOr<U> Function(T) op, U opt) {
     return Future.value(this).then((option) {
-      final val = option.toNullable();
-      return val != null ? op(val) : opt;
+      if (this case Some(:final some)) {
+        return op(some);
+      } else {
+        return opt;
+      }
     });
   }
 
@@ -40,9 +42,11 @@ extension OptionMapFilterAsyncX<T extends Object> on FutureOr<Option<T>> {
   /// * `None` if predicate returns `false`.
   Future<Option<T>> filterAsync(FutureOr<bool> Function(T) predicate) {
     return Future.value(this).then((option) {
-      final val = option.toNullable();
-      if (val == null) return None<T>();
-      return Future.value(predicate(val)).then((v) => v ? this : None<T>());
+      if (this case Some(:final some)) {
+        return Future.value(predicate(some)).then((v) => v ? this : None<T>());
+      } else {
+        return const None();
+      }
     });
   }
 }

--- a/lib/src/option_async_utils/option_match_async_extension.dart
+++ b/lib/src/option_async_utils/option_match_async_extension.dart
@@ -1,7 +1,7 @@
 part of 'option_async_utils.dart';
 
 /// Collection of methods to work with [Future] on [OptionMatchMixin]
-extension OptionMatchAsyncX<T extends Object> on FutureOr<Option<T>> {
+extension OptionMatchAsyncX<T> on FutureOr<Option<T>> {
   /// Asynchronously invokes either the `someop` or the `noneop` depending on
   /// the option.
   ///

--- a/lib/src/option_async_utils/option_to_result_async_extension.dart
+++ b/lib/src/option_async_utils/option_to_result_async_extension.dart
@@ -1,8 +1,7 @@
 part of 'option_async_utils.dart';
 
 /// Async method like okOrElse
-extension OptionToResultAsyncExtension<T extends Object>
-    on FutureOr<Option<T>> {
+extension OptionToResultAsyncExtension<T> on FutureOr<Option<T>> {
   /// Transforms the `Option<T>` into a `Result<T, E>`, mapping `Some(v)` to
   /// `Ok(v)` and `None` to `Err(err())`.
   Future<Result<T, E>> okOrElseAsync<E extends Object>(

--- a/lib/src/option_async_utils/option_unwrap_async_extension.dart
+++ b/lib/src/option_async_utils/option_unwrap_async_extension.dart
@@ -1,7 +1,7 @@
 part of 'option_async_utils.dart';
 
 /// Async methods related to unwrap for [Option]
-extension OptionUnwrapAsyncX<T extends Object> on FutureOr<Option<T>> {
+extension OptionUnwrapAsyncX<T> on FutureOr<Option<T>> {
   /// Returns the contained value or asynchronously computes it from a closure.
   Future<T> unwrapOrElseAsync(FutureOr<T> Function() op) {
     return matchAsync((some) => some, op);

--- a/lib/src/option_utils/option_future_redirector.dart
+++ b/lib/src/option_utils/option_future_redirector.dart
@@ -8,10 +8,10 @@ extension OptionFutureRedirector<T> on Future<Option<T>> {
   /// If Option has a None value, it will return `null`.
   Future<T?> toNullable() => then((v) => v.toNullable());
 
-  /// Returns `true` if the option is a `Some` value.
+  /// Returns `true` if the option is a [Some] value.
   Future<bool> isSome() => then((v) => v.isSome());
 
-  /// Returns `true` if the option is a `None` value.
+  /// Returns `true` if the option is a [None] value.
   Future<bool> isNone() => then((v) => v.isNone());
 
   /// Invokes either the `someop` or the `noneop` depending on the option.
@@ -37,9 +37,9 @@ extension OptionFutureRedirector<T> on Future<Option<T>> {
   /// Throws an `Exception` if the value is a [None], with the passed message.
   Future<T> expect(String msg) => then((v) => v.expect(msg));
 
-  /// Unwraps an option, yielding the content of a `Some`.
+  /// Unwraps an option, yielding the content of a [Some].
   ///
-  /// Throws an empty exception if this result is a `None`.
+  /// Throws an empty exception if this result is a [None].
   Future<T> unwrap() => then((v) => v.unwrap());
 
   /// Returns the contained value or a default.
@@ -49,7 +49,7 @@ extension OptionFutureRedirector<T> on Future<Option<T>> {
   Future<T> unwrapOrElse(T Function() op) => unwrapOrElseAsync(op);
 
   /// Maps an `Option<T>` to `Option<U>` by applying a function to a contained
-  /// `Some` value. Otherwise returns a `None`.
+  /// [Some] value. Otherwise returns a `None`.
   Future<Option<U>> map<U>(U Function(T) op) => mapAsync(op);
 
   /// Applies a function to the contained value (if any), or returns the
@@ -79,10 +79,10 @@ extension OptionFutureRedirector<T> on Future<Option<T>> {
   Future<Option<T>> filter(bool Function(T) predicate) =>
       filterAsync(predicate);
 
-  /// Returns `None` if the option is `None`, otherwise returns `optb`.
+  /// Returns [None] if the option is [None], otherwise returns `optb`.
   Future<Option<U>> and<U>(Option<U> optb) => then((v) => v.and(optb));
 
-  /// Returns `None` if the option is `None`, otherwise calls `op` with the
+  /// Returns [None] if the option is [None], otherwise calls `op` with the
   /// wrapped value and returns the result.
   Future<Option<U>> andThen<U>(Option<U> Function(T) op) => andThenAsync(op);
 
@@ -93,7 +93,7 @@ extension OptionFutureRedirector<T> on Future<Option<T>> {
   /// returns the result.
   Future<Option<T>> orElse(Option<T> Function() op) => orElseAsync(op);
 
-  /// Returns `Some` if exactly one of `this`, `optb` is `Some`, otherwise
-  /// returns `None`.
+  /// Returns [Some] if exactly one of `this`, `optb` is [Some], otherwise
+  /// returns [None].
   Future<Option<T>> xor(Option<T> optb) => then((v) => v.xor(optb));
 }

--- a/lib/src/option_utils/option_future_redirector.dart
+++ b/lib/src/option_utils/option_future_redirector.dart
@@ -1,7 +1,7 @@
 part of 'option_utils.dart';
 
 /// Collection of utils on [Future<Option<T>>]
-extension OptionFutureRedirector<T extends Object> on Future<Option<T>> {
+extension OptionFutureRedirector<T> on Future<Option<T>> {
   /// Returns an nullable that represents this optional value.
   ///
   /// If Option has Some value, it will return that value.
@@ -50,7 +50,7 @@ extension OptionFutureRedirector<T extends Object> on Future<Option<T>> {
 
   /// Maps an `Option<T>` to `Option<U>` by applying a function to a contained
   /// `Some` value. Otherwise returns a `None`.
-  Future<Option<U>> map<U extends Object>(U Function(T) op) => mapAsync(op);
+  Future<Option<U>> map<U>(U Function(T) op) => mapAsync(op);
 
   /// Applies a function to the contained value (if any), or returns the
   /// provided default (if not).
@@ -80,13 +80,11 @@ extension OptionFutureRedirector<T extends Object> on Future<Option<T>> {
       filterAsync(predicate);
 
   /// Returns `None` if the option is `None`, otherwise returns `optb`.
-  Future<Option<U>> and<U extends Object>(Option<U> optb) =>
-      then((v) => v.and(optb));
+  Future<Option<U>> and<U>(Option<U> optb) => then((v) => v.and(optb));
 
   /// Returns `None` if the option is `None`, otherwise calls `op` with the
   /// wrapped value and returns the result.
-  Future<Option<U>> andThen<U extends Object>(Option<U> Function(T) op) =>
-      andThenAsync(op);
+  Future<Option<U>> andThen<U>(Option<U> Function(T) op) => andThenAsync(op);
 
   /// Returns the option if it contains a value, otherwise returns `optb`.
   Future<Option<T>> or(Option<T> optb) => then((v) => v.or(optb));

--- a/lib/src/option_utils/option_option_flattener.dart
+++ b/lib/src/option_utils/option_option_flattener.dart
@@ -1,7 +1,7 @@
 part of 'option_utils.dart';
 
 /// Flat utils on [Option<Option<T>>]
-extension OptionOptionFlattener<T extends Object> on Option<Option<T>> {
+extension OptionOptionFlattener<T> on Option<Option<T>> {
   /// Flats an option of an option.
   ///
   /// ```dart
@@ -21,8 +21,7 @@ extension OptionOptionFlattener<T extends Object> on Option<Option<T>> {
 }
 
 /// Flat utils on [Future<Option<Option<T>>>]
-extension FutureOptionOptionFlattener<T extends Object>
-    on Future<Option<Option<T>>> {
+extension FutureOptionOptionFlattener<T> on Future<Option<Option<T>>> {
   /// Flats an option of an option.
   ///
   /// ```dart

--- a/lib/src/option_utils/option_result_transposer.dart
+++ b/lib/src/option_utils/option_result_transposer.dart
@@ -1,8 +1,7 @@
 part of 'option_utils.dart';
 
 /// Utils for transposing [Option<Result<T, E>>] to [Result<Option<T>, E>]
-extension OptionResultTransposer<T extends Object, E extends Object>
-    on Option<Result<T, E>> {
+extension OptionResultTransposer<T, E extends Object> on Option<Result<T, E>> {
   /// Transposes the result of an option.
   ///
   /// ```dart
@@ -25,7 +24,7 @@ extension OptionResultTransposer<T extends Object, E extends Object>
 
 /// Utils for transposing [Future<Option<Result<T, E>>>]
 /// to [Future<Result<Option<T>, E>>]
-extension FutureOptionResultTransposer<T extends Object, E extends Object>
+extension FutureOptionResultTransposer<T, E extends Object>
     on Future<Option<Result<T, E>>> {
   /// Transposes the result of an option.
   ///

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -24,7 +24,7 @@ sealed class Result<T, E extends Object> extends Equatable {
   ///
   /// If the function throws an error, it will be caught and contained in the
   /// returned result. Otherwise, the result of the function will be contained
-  /// as the `Ok` value.
+  /// as the [Ok] value.
   factory Result.of(T Function() catching) {
     try {
       return Ok(catching());
@@ -47,10 +47,10 @@ sealed class Result<T, E extends Object> extends Equatable {
     }
   }
 
-  /// Returns `true` if the option is a `Ok` value.
+  /// Returns `true` if the option is a [Ok] value.
   bool isOk();
 
-  /// Returns `true` if the option is a `Err` value.
+  /// Returns `true` if the option is a [Err] value.
   bool isErr();
 
   /// Invokes either the `okop` or the `errop` depending on the result.
@@ -62,10 +62,10 @@ sealed class Result<T, E extends Object> extends Equatable {
   /// See also [when] for another way to achieve the same behavior.
   R match<R>(R Function(T) okop, R Function(E) errop);
 
-  /// Invokes the `okop` if the result is `Ok`, otherwise does nothing.
+  /// Invokes the `okop` if the result is [Ok], otherwise does nothing.
   R? matchOk<R>(R Function(T) okop);
 
-  /// Invokes the `errop` if the result is `Err`, otherwise does nothing.
+  /// Invokes the `errop` if the result is [Err], otherwise does nothing.
   R? matchErr<R>(R Function(E) errop);
 
   /// Asynchronously invokes either the `okop` or the `errop` depending on
@@ -108,41 +108,41 @@ sealed class Result<T, E extends Object> extends Equatable {
     Future<F> Function(E) err,
   );
 
-  /// Converts the `Result` into an `Option` containing the value, if any.
-  /// Otherwise returns `None` if the result is an error.
+  /// Converts the [Result] into an [Option] containing the value, if any.
+  /// Otherwise returns [None] if the result is an error.
   Option<T> ok();
 
-  /// Converts the `Result` into an `Option` containing the error, if any.
-  /// Otherwise returns `None` if the result is a value.
+  /// Converts the [Result] into an [Option] containing the error, if any.
+  /// Otherwise returns [None] if the result is a value.
   Option<E> err();
 
-  /// Unwraps a result, yielding the content of an `Ok`.
+  /// Unwraps a result, yielding the content of an [Ok].
   ///
-  /// Throws an `Exception` if the value is an `Err`, with the passed message.
+  /// Throws an `Exception` if the value is an [Err], with the passed message.
   T expect(String msg);
 
-  /// Unwraps a result, yielding the content of an `Err`.
+  /// Unwraps a result, yielding the content of an [Err].
   ///
-  /// Throws an `Exception` if the value is an `Ok`, with the passed message.
+  /// Throws an `Exception` if the value is an [Ok], with the passed message.
   E expectErr(String msg);
 
   /// Maps a `Result<T, E>` to `Result<U, E>` by applying a function to a
-  /// contained `Ok` value, leaving an `Err` value untouched.
+  /// contained [Ok] value, leaving an [Err] value untouched.
   Result<U, E> map<U>(U Function(T) op);
 
   /// Maps a `Result<T, E>` to `Result<U, E>` by applying an asynchronous
-  /// function to a contained `Ok` value, leaving an `Err` value untouched.
+  /// function to a contained [Ok] value, leaving an [Err] value untouched.
   Future<Result<U, E>> mapAsync<U>(Future<U> Function(T) op);
 
   /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to
-  /// a contained `Err` value, leaving an `Ok` value untouched.
+  /// a contained [Err] value, leaving an [Ok] value untouched.
   ///
   /// This function can be used to pass through a successful result while
   /// handling an error.
   Result<T, F> mapErr<F extends Object>(F Function(E) op);
 
   /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to
-  /// a contained `Err` value, leaving an `Ok` value untouched.
+  /// a contained [Err] value, leaving an [Ok] value untouched.
   ///
   /// This function can be used to pass through a successful result while
   /// handling an error.
@@ -157,69 +157,69 @@ sealed class Result<T, E extends Object> extends Equatable {
   Future<U> mapOrAsync<U>(Future<U> Function(T) op, U opt);
 
   /// Maps a `Result<T, E>` to `U` by applying a function to a contained
-  /// `Ok` value, or a fallback function to a contained `Err` value.
+  /// [Ok] value, or a fallback function to a contained [Err] value.
   U mapOrElse<U>(U Function(T) op, U Function(E) errOp);
 
   /// Maps a `Result<T, E>` to `U` by applying a function to a contained
-  /// `Ok` value, or a fallback function to a contained `Err` value.
+  /// [Ok] value, or a fallback function to a contained [Err] value.
   Future<U> mapOrElseAsync<U>(
     Future<U> Function(T) op,
     Future<U> Function(E) errOp,
   );
 
-  /// Returns `res` if the result is `Ok`, otherwise returns `this`.
+  /// Returns `res` if the result is [Ok], otherwise returns `this`.
   Result<U, E> and<U>(Result<U, E> res);
 
-  /// Calls `op` with the `Ok` value if the result is `Ok`, otherwise returns
+  /// Calls `op` with the [Ok] value if the result is [Ok], otherwise returns
   /// `this`.
   Result<U, E> andThen<U>(Result<U, E> Function(T) op);
 
-  /// Asynchronously calls `op` with the `Ok` value if the result is `Ok`,
+  /// Asynchronously calls `op` with the [Ok] value if the result is [Ok],
   /// otherwise returns `this`.
   Future<Result<U, E>> andThenAsync<U>(Future<Result<U, E>> Function(T) op);
 
-  /// Returns `res` if the result is an `Err`, otherwise returns `this`.
+  /// Returns `res` if the result is an [Err], otherwise returns `this`.
   Result<T, F> or<F extends Object>(Result<T, F> res);
 
-  /// Calls `op` with the `Err` value if the result is `Err`, otherwise returns
+  /// Calls `op` with the [Err] value if the result is [Err], otherwise returns
   /// `this`.
   Result<T, F> orElse<F extends Object>(Result<T, F> Function(E) op);
 
-  /// Calls `op` with the `Err` value if the result is `Err`, otherwise returns
+  /// Calls `op` with the [Err] value if the result is [Err], otherwise returns
   /// `this`.
   Future<Result<T, F>> orElseAsync<F extends Object>(
     Future<Result<T, F>> Function(E) op,
   );
 
-  /// Unwraps a result, yielding the content of an `Ok`.
+  /// Unwraps a result, yielding the content of an [Ok].
   ///
-  /// Throws the contained error if this result is an `Err`.
+  /// Throws the contained error if this result is an [Err].
   T unwrap();
 
-  /// Unwraps a result, yielding the content of an `Ok`.
+  /// Unwraps a result, yielding the content of an [Ok].
   ///
-  /// If the value is an `Err`, returns `null` instead of throwing an exception.
+  /// If the value is an [Err], returns `null` instead of throwing an exception.
   T? unwrapOrNull();
 
-  /// Unwraps a result, yielding the content of an `Err`.
+  /// Unwraps a result, yielding the content of an [Err].
   ///
-  /// Throws an exception if the value is an `Ok`, with a custom message
-  /// provided by calling `toString()` on the `Ok`'s value.
+  /// Throws an exception if the value is an [Ok], with a custom message
+  /// provided by calling `toString()` on the [Ok]'s value.
   E unwrapErr();
 
-  /// Unwraps a result, yielding the content of an `Ok`. Else, it returns `opt`.
+  /// Unwraps a result, yielding the content of an [Ok]. Else, it returns `opt`.
   T unwrapOr(T opt);
 
-  /// Unwraps a result, yielding the content of an `Ok`. If the value is an
-  /// `Err` then it calls `op` with its value.
+  /// Unwraps a result, yielding the content of an [Ok]. If the value is an
+  /// [Err] then it calls `op` with its value.
   T unwrapOrElse(T Function(E) op);
 
-  /// Unwraps a result, yielding the content of an `Ok`. If the value is an
-  /// `Err` then it asynchronously calls `op` with its value.
+  /// Unwraps a result, yielding the content of an [Ok]. If the value is an
+  /// [Err] then it asynchronously calls `op` with its value.
   Future<T> unwrapOrElseAsync(Future<T> Function(E) op);
 }
 
-/// An `Ok<T, E>` is a `Result` that represents the successful value.
+/// An `Ok<T, E>` is a [Result] that represents the successful value.
 ///
 /// You can create an `Ok` using either the `Ok()` constructor or the
 /// `Result.ok()` factory constructor.
@@ -371,7 +371,7 @@ class Ok<T, E extends Object> extends Result<T, E> {
   static Ok<Unit, E> unit<E extends Object>() => Ok<Unit, E>(Unit.unit);
 }
 
-/// An `Err<T, E>` is a `Result` that represents a failure.
+/// An `Err<T, E>` is a [Result] that represents a failure.
 ///
 /// You can create an `Err` using either the `Err(E)` constructor or the
 /// `Result.err(E)` factory constructor.

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -11,7 +11,7 @@ import 'package:oxidized/src/unit.dart';
 /// `Result<T, E>` is the type used for returning and propagating errors. It is
 /// an object with an `Ok` value, representing success and containing a value,
 /// and `Err`, representing error and containing an error value.
-sealed class Result<T extends Object, E extends Object> extends Equatable {
+sealed class Result<T, E extends Object> extends Equatable {
   const Result._();
 
   /// Create an `Ok` result with the given value.
@@ -37,7 +37,7 @@ sealed class Result<T extends Object, E extends Object> extends Equatable {
   ///
   /// see also:
   /// - `Result.of`
-  static Future<Result<T, E>> asyncOf<T extends Object, E extends Object>(
+  static Future<Result<T, E>> asyncOf<T, E extends Object>(
     Future<T> Function() catching,
   ) async {
     try {
@@ -97,16 +97,13 @@ sealed class Result<T extends Object, E extends Object> extends Equatable {
   /// Invoke either the `ok` or the `err` function based on the result.
   ///
   /// This is a combination of the [map()] and [mapErr()] functions.
-  Result<U, F> fold<U extends Object, F extends Object>(
-    U Function(T) ok,
-    F Function(E) err,
-  );
+  Result<U, F> fold<U, F extends Object>(U Function(T) ok, F Function(E) err);
 
   /// Asynchronously invoke either the `ok` or the `err` function based on
   /// the result.
   ///
   /// This is a combination of the [map()] and [mapErr()] functions.
-  Future<Result<U, F>> foldAsync<U extends Object, F extends Object>(
+  Future<Result<U, F>> foldAsync<U, F extends Object>(
     Future<U> Function(T) ok,
     Future<F> Function(E) err,
   );
@@ -131,11 +128,11 @@ sealed class Result<T extends Object, E extends Object> extends Equatable {
 
   /// Maps a `Result<T, E>` to `Result<U, E>` by applying a function to a
   /// contained `Ok` value, leaving an `Err` value untouched.
-  Result<U, E> map<U extends Object>(U Function(T) op);
+  Result<U, E> map<U>(U Function(T) op);
 
   /// Maps a `Result<T, E>` to `Result<U, E>` by applying an asynchronous
   /// function to a contained `Ok` value, leaving an `Err` value untouched.
-  Future<Result<U, E>> mapAsync<U extends Object>(Future<U> Function(T) op);
+  Future<Result<U, E>> mapAsync<U>(Future<U> Function(T) op);
 
   /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to
   /// a contained `Err` value, leaving an `Ok` value untouched.
@@ -171,17 +168,15 @@ sealed class Result<T extends Object, E extends Object> extends Equatable {
   );
 
   /// Returns `res` if the result is `Ok`, otherwise returns `this`.
-  Result<U, E> and<U extends Object>(Result<U, E> res);
+  Result<U, E> and<U>(Result<U, E> res);
 
   /// Calls `op` with the `Ok` value if the result is `Ok`, otherwise returns
   /// `this`.
-  Result<U, E> andThen<U extends Object>(Result<U, E> Function(T) op);
+  Result<U, E> andThen<U>(Result<U, E> Function(T) op);
 
   /// Asynchronously calls `op` with the `Ok` value if the result is `Ok`,
   /// otherwise returns `this`.
-  Future<Result<U, E>> andThenAsync<U extends Object>(
-    Future<Result<U, E>> Function(T) op,
-  );
+  Future<Result<U, E>> andThenAsync<U>(Future<Result<U, E>> Function(T) op);
 
   /// Returns `res` if the result is an `Err`, otherwise returns `this`.
   Result<T, F> or<F extends Object>(Result<T, F> res);
@@ -228,7 +223,7 @@ sealed class Result<T extends Object, E extends Object> extends Equatable {
 ///
 /// You can create an `Ok` using either the `Ok()` constructor or the
 /// `Result.ok()` factory constructor.
-class Ok<T extends Object, E extends Object> extends Result<T, E> {
+class Ok<T, E extends Object> extends Result<T, E> {
   /// Create an `Ok` result with the given value.
   const Ok(T s)
       : _ok = s,
@@ -264,10 +259,7 @@ class Ok<T extends Object, E extends Object> extends Result<T, E> {
   R when<R>({required R Function(T) ok, required R Function(E) err}) => ok(_ok);
 
   @override
-  Result<U, F> fold<U extends Object, F extends Object>(
-    U Function(T) ok,
-    F Function(E) err,
-  ) =>
+  Result<U, F> fold<U, F extends Object>(U Function(T) ok, F Function(E) err) =>
       Ok(ok(_ok));
 
   @override
@@ -283,7 +275,7 @@ class Ok<T extends Object, E extends Object> extends Result<T, E> {
   E expectErr(String msg) => throw ResultUnwrapException<T, E>(msg);
 
   @override
-  Result<U, E> map<U extends Object>(U Function(T) op) => Ok(op(_ok));
+  Result<U, E> map<U>(U Function(T) op) => Ok(op(_ok));
 
   @override
   Result<T, F> mapErr<F extends Object>(F Function(E) op) => Ok(_ok);
@@ -295,11 +287,10 @@ class Ok<T extends Object, E extends Object> extends Result<T, E> {
   U mapOrElse<U>(U Function(T) op, U Function(E) errOp) => op(_ok);
 
   @override
-  Result<U, E> and<U extends Object>(Result<U, E> res) => res;
+  Result<U, E> and<U>(Result<U, E> res) => res;
 
   @override
-  Result<U, E> andThen<U extends Object>(Result<U, E> Function(T) op) =>
-      op(_ok);
+  Result<U, E> andThen<U>(Result<U, E> Function(T) op) => op(_ok);
 
   @override
   Result<T, F> or<F extends Object>(Result<T, F> res) => Ok(_ok);
@@ -323,22 +314,18 @@ class Ok<T extends Object, E extends Object> extends Result<T, E> {
   T unwrapOrElse(T Function(E) op) => _ok;
 
   @override
-  Future<Result<U, E>> andThenAsync<U extends Object>(
-    Future<Result<U, E>> Function(T) op,
-  ) =>
+  Future<Result<U, E>> andThenAsync<U>(Future<Result<U, E>> Function(T) op) =>
       op(_ok);
 
   @override
-  Future<Result<U, F>> foldAsync<U extends Object, F extends Object>(
+  Future<Result<U, F>> foldAsync<U, F extends Object>(
     Future<U> Function(T) ok,
     Future<F> Function(E) err,
   ) =>
       ok(_ok).then(Ok.new);
 
   @override
-  Future<Result<U, E>> mapAsync<U extends Object>(
-    Future<U> Function(T) op,
-  ) =>
+  Future<Result<U, E>> mapAsync<U>(Future<U> Function(T) op) =>
       op(_ok).then(Ok.new);
 
   @override
@@ -388,7 +375,7 @@ class Ok<T extends Object, E extends Object> extends Result<T, E> {
 ///
 /// You can create an `Err` using either the `Err(E)` constructor or the
 /// `Result.err(E)` factory constructor.
-class Err<T extends Object, E extends Object> extends Result<T, E> {
+class Err<T, E extends Object> extends Result<T, E> {
   /// Create an `Err` result with the given error.
   const Err(E err)
       : _err = err,
@@ -425,10 +412,7 @@ class Err<T extends Object, E extends Object> extends Result<T, E> {
       err(_err);
 
   @override
-  Result<U, F> fold<U extends Object, F extends Object>(
-    U Function(T) ok,
-    F Function(E) err,
-  ) =>
+  Result<U, F> fold<U, F extends Object>(U Function(T) ok, F Function(E) err) =>
       Err(err(_err));
 
   @override
@@ -446,7 +430,7 @@ class Err<T extends Object, E extends Object> extends Result<T, E> {
   E expectErr(String msg) => _err;
 
   @override
-  Result<U, E> map<U extends Object>(U Function(T) op) => Err(_err);
+  Result<U, E> map<U>(U Function(T) op) => Err(_err);
 
   @override
   Result<T, F> mapErr<F extends Object>(F Function(E) op) => Err(op(_err));
@@ -458,11 +442,10 @@ class Err<T extends Object, E extends Object> extends Result<T, E> {
   U mapOrElse<U>(U Function(T) op, U Function(E) errOp) => errOp(_err);
 
   @override
-  Result<U, E> and<U extends Object>(Result<U, E> res) => Err(_err);
+  Result<U, E> and<U>(Result<U, E> res) => Err(_err);
 
   @override
-  Result<U, E> andThen<U extends Object>(Result<U, E> Function(T) op) =>
-      Err(_err);
+  Result<U, E> andThen<U>(Result<U, E> Function(T) op) => Err(_err);
 
   @override
   Result<T, F> or<F extends Object>(Result<T, F> res) => res;
@@ -487,22 +470,18 @@ class Err<T extends Object, E extends Object> extends Result<T, E> {
   T unwrapOrElse(T Function(E) op) => op(_err);
 
   @override
-  Future<Result<U, E>> andThenAsync<U extends Object>(
-    Future<Result<U, E>> Function(T) op,
-  ) =>
+  Future<Result<U, E>> andThenAsync<U>(Future<Result<U, E>> Function(T) op) =>
       Future.value(Err(_err));
 
   @override
-  Future<Result<U, F>> foldAsync<U extends Object, F extends Object>(
+  Future<Result<U, F>> foldAsync<U, F extends Object>(
     Future<U> Function(T) ok,
     Future<F> Function(E) err,
   ) =>
       err(_err).then(Err.new);
 
   @override
-  Future<Result<U, E>> mapAsync<U extends Object>(
-    Future<U> Function(T) op,
-  ) =>
+  Future<Result<U, E>> mapAsync<U>(Future<U> Function(T) op) =>
       Future.value(Err(_err));
 
   @override

--- a/lib/src/result_utils/result_future_redirector.dart
+++ b/lib/src/result_utils/result_future_redirector.dart
@@ -1,8 +1,7 @@
 part of 'result_utils.dart';
 
 /// enable [Result<T, E>] methods in a [Future<Result<T, E>>]
-extension ResultFutureRedirector<T extends Object, E extends Object>
-    on Future<Result<T, E>> {
+extension ResultFutureRedirector<T, E extends Object> on Future<Result<T, E>> {
   /// Returns `true` if the option is a `Ok` value.
   Future<bool> isOk() => then((result) => result.isOk());
 
@@ -59,7 +58,7 @@ extension ResultFutureRedirector<T extends Object, E extends Object>
   /// Invoke either the `ok` or the `err` function based on the result.
   ///
   /// This is a combination of the [map()] and [mapErr()] functions.
-  Future<Result<U, F>> fold<U extends Object, F extends Object>(
+  Future<Result<U, F>> fold<U, F extends Object>(
     U Function(T) ok,
     F Function(E) err,
   ) =>
@@ -69,7 +68,7 @@ extension ResultFutureRedirector<T extends Object, E extends Object>
   /// the result.
   ///
   /// This is a combination of the [map()] and [mapErr()] functions.
-  Future<Result<U, F>> foldAsync<U extends Object, F extends Object>(
+  Future<Result<U, F>> foldAsync<U, F extends Object>(
     Future<U> Function(T) ok,
     Future<F> Function(E) err,
   ) =>
@@ -95,12 +94,12 @@ extension ResultFutureRedirector<T extends Object, E extends Object>
 
   /// Maps a `Result<T, E>` to `Result<U, E>` by applying a function to a
   /// contained `Ok` value, leaving an `Err` value untouched.
-  Future<Result<U, E>> map<U extends Object>(U Function(T) op) =>
+  Future<Result<U, E>> map<U>(U Function(T) op) =>
       then((result) => result.map(op));
 
   /// Maps a `Result<T, E>` to `Result<U, E>` by applying an asynchronous
   /// function to a contained `Ok` value, leaving an `Err` value untouched.
-  Future<Result<U, E>> mapAsync<U extends Object>(Future<U> Function(T) op) =>
+  Future<Result<U, E>> mapAsync<U>(Future<U> Function(T) op) =>
       then((result) => result.mapAsync(op));
 
   /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to
@@ -146,19 +145,17 @@ extension ResultFutureRedirector<T extends Object, E extends Object>
       then((result) => result.mapOrElseAsync(op, errOp));
 
   /// Returns `res` if the result is `Ok`, otherwise returns `this`.
-  Future<Result<U, E>> and<U extends Object>(Result<U, E> res) =>
+  Future<Result<U, E>> and<U>(Result<U, E> res) =>
       then((result) => result.and(res));
 
   /// Calls `op` with the `Ok` value if the result is `Ok`, otherwise returns
   /// `this`.
-  Future<Result<U, E>> andThen<U extends Object>(Result<U, E> Function(T) op) =>
+  Future<Result<U, E>> andThen<U>(Result<U, E> Function(T) op) =>
       then((result) => result.andThen(op));
 
   /// Asynchronously calls `op` with the `Ok` value if the result is `Ok`,
   /// otherwise returns `this`.
-  Future<Result<U, E>> andThenAsync<U extends Object>(
-    Future<Result<U, E>> Function(T) op,
-  ) =>
+  Future<Result<U, E>> andThenAsync<U>(Future<Result<U, E>> Function(T) op) =>
       then((result) => result.andThenAsync(op));
 
   /// Returns `res` if the result is an `Err`, otherwise returns `this`.

--- a/lib/src/result_utils/result_future_redirector.dart
+++ b/lib/src/result_utils/result_future_redirector.dart
@@ -2,10 +2,10 @@ part of 'result_utils.dart';
 
 /// enable [Result<T, E>] methods in a [Future<Result<T, E>>]
 extension ResultFutureRedirector<T, E extends Object> on Future<Result<T, E>> {
-  /// Returns `true` if the option is a `Ok` value.
+  /// Returns `true` if the option is a [Ok] value.
   Future<bool> isOk() => then((result) => result.isOk());
 
-  /// Returns `true` if the option is a `Err` value.
+  /// Returns `true` if the option is a [Err] value.
   Future<bool> isErr() => then((result) => result.isErr());
 
   /// Invokes either the `okop` or the `errop` depending on the result.
@@ -18,11 +18,11 @@ extension ResultFutureRedirector<T, E extends Object> on Future<Result<T, E>> {
   Future<R> match<R>(R Function(T) okop, R Function(E) errop) =>
       then((result) => result.match(okop, errop));
 
-  /// Invokes the `okop` if the result is `Ok`, otherwise does nothing.
+  /// Invokes the `okop` if the result is [Ok], otherwise does nothing.
   Future<R?> matchOk<R>(R Function(T) okop) =>
       then((result) => result.matchOk(okop));
 
-  /// Invokes the `errop` if the result is `Err`, otherwise does nothing.
+  /// Invokes the `errop` if the result is [Err], otherwise does nothing.
   Future<R?> matchErr<R>(R Function(E) errop) =>
       then((result) => result.matchErr(errop));
 
@@ -82,28 +82,28 @@ extension ResultFutureRedirector<T, E extends Object> on Future<Result<T, E>> {
   /// Otherwise returns `None` if the result is a value.
   Future<Option<E>> err() => then((result) => result.err());
 
-  /// Unwraps a result, yielding the content of an `Ok`.
+  /// Unwraps a result, yielding the content of an [Ok].
   ///
-  /// Throws an `Exception` if the value is an `Err`, with the passed message.
+  /// Throws an `Exception` if the value is an [Err], with the passed message.
   Future<T> expect(String msg) => then((result) => result.expect(msg));
 
-  /// Unwraps a result, yielding the content of an `Err`.
+  /// Unwraps a result, yielding the content of an [Err].
   ///
-  /// Throws an `Exception` if the value is an `Ok`, with the passed message.
+  /// Throws an `Exception` if the value is an [Ok], with the passed message.
   Future<E> expectErr(String msg) => then((result) => result.expectErr(msg));
 
   /// Maps a `Result<T, E>` to `Result<U, E>` by applying a function to a
-  /// contained `Ok` value, leaving an `Err` value untouched.
+  /// contained [Ok] value, leaving an [Err] value untouched.
   Future<Result<U, E>> map<U>(U Function(T) op) =>
       then((result) => result.map(op));
 
   /// Maps a `Result<T, E>` to `Result<U, E>` by applying an asynchronous
-  /// function to a contained `Ok` value, leaving an `Err` value untouched.
+  /// function to a contained [Ok] value, leaving an [Err] value untouched.
   Future<Result<U, E>> mapAsync<U>(Future<U> Function(T) op) =>
       then((result) => result.mapAsync(op));
 
   /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to
-  /// a contained `Err` value, leaving an `Ok` value untouched.
+  /// a contained [Err] value, leaving an [Ok] value untouched.
   ///
   /// This function can be used to pass through a successful result while
   /// handling an error.
@@ -111,7 +111,7 @@ extension ResultFutureRedirector<T, E extends Object> on Future<Result<T, E>> {
       then((result) => result.mapErr(op));
 
   /// Maps a `Result<T, E>` to `Result<T, F>` by applying a function to
-  /// a contained `Err` value, leaving an `Ok` value untouched.
+  /// a contained [Err] value, leaving an [Ok] value untouched.
   ///
   /// This function can be used to pass through a successful result while
   /// handling an error.
@@ -132,74 +132,74 @@ extension ResultFutureRedirector<T, E extends Object> on Future<Result<T, E>> {
       then((result) => result.mapOrAsync(op, opt));
 
   /// Maps a `Result<T, E>` to `U` by applying a function to a contained
-  /// `Ok` value, or a fallback function to a contained `Err` value.
+  /// [Ok] value, or a fallback function to a contained [Err] value.
   Future<U> mapOrElse<U>(U Function(T) op, U Function(E) errOp) =>
       then((result) => result.mapOrElse(op, errOp));
 
   /// Maps a `Result<T, E>` to `U` by applying a function to a contained
-  /// `Ok` value, or a fallback function to a contained `Err` value.
+  /// [Ok] value, or a fallback function to a contained [Err] value.
   Future<U> mapOrElseAsync<U>(
     Future<U> Function(T) op,
     Future<U> Function(E) errOp,
   ) =>
       then((result) => result.mapOrElseAsync(op, errOp));
 
-  /// Returns `res` if the result is `Ok`, otherwise returns `this`.
+  /// Returns `res` if the result is [Ok], otherwise returns `this`.
   Future<Result<U, E>> and<U>(Result<U, E> res) =>
       then((result) => result.and(res));
 
-  /// Calls `op` with the `Ok` value if the result is `Ok`, otherwise returns
+  /// Calls `op` with the [Ok] value if the result is [Ok], otherwise returns
   /// `this`.
   Future<Result<U, E>> andThen<U>(Result<U, E> Function(T) op) =>
       then((result) => result.andThen(op));
 
-  /// Asynchronously calls `op` with the `Ok` value if the result is `Ok`,
+  /// Asynchronously calls `op` with the [Ok] value if the result is [Ok],
   /// otherwise returns `this`.
   Future<Result<U, E>> andThenAsync<U>(Future<Result<U, E>> Function(T) op) =>
       then((result) => result.andThenAsync(op));
 
-  /// Returns `res` if the result is an `Err`, otherwise returns `this`.
+  /// Returns `res` if the result is an [Err], otherwise returns `this`.
   Future<Result<T, F>> or<F extends Object>(Result<T, F> res) =>
       then((result) => result.or(res));
 
-  /// Calls `op` with the `Err` value if the result is `Err`, otherwise returns
+  /// Calls `op` with the [Err] value if the result is [Err], otherwise returns
   /// `this`.
   Future<Result<T, F>> orElse<F extends Object>(Result<T, F> Function(E) op) =>
       then((result) => result.orElse(op));
 
-  /// Calls `op` with the `Err` value if the result is `Err`, otherwise returns
+  /// Calls `op` with the [Err] value if the result is [Err], otherwise returns
   /// `this`.
   Future<Result<T, F>> orElseAsync<F extends Object>(
     Future<Result<T, F>> Function(E) op,
   ) =>
       then((result) => result.orElseAsync(op));
 
-  /// Unwraps a result, yielding the content of an `Ok`.
+  /// Unwraps a result, yielding the content of an [Ok].
   ///
-  /// Throws the contained error if this result is an `Err`.
+  /// Throws the contained error if this result is an [Err].
   Future<T> unwrap() => then((result) => result.unwrap());
 
-  /// Unwraps a result, yielding the content of an `Ok`.
+  /// Unwraps a result, yielding the content of an [Ok].
   ///
-  /// If the value is an `Err`, returns `null` instead of throwing an exception.
+  /// If the value is an [Err], returns `null` instead of throwing an exception.
   Future<T?> unwrapOrNull() => then((result) => result.unwrapOrNull());
 
-  /// Unwraps a result, yielding the content of an `Err`.
+  /// Unwraps a result, yielding the content of an [Err].
   ///
-  /// Throws an exception if the value is an `Ok`, with a custom message
-  /// provided by calling `toString()` on the `Ok`'s value.
+  /// Throws an exception if the value is an [Ok], with a custom message
+  /// provided by calling `toString()` on the [Ok]'s value.
   Future<E> unwrapErr() => then((result) => result.unwrapErr());
 
-  /// Unwraps a result, yielding the content of an `Ok`. Else, it returns `opt`.
+  /// Unwraps a result, yielding the content of an [Ok]. Else, it returns `opt`.
   Future<T> unwrapOr(T opt) => then((result) => result.unwrapOr(opt));
 
-  /// Unwraps a result, yielding the content of an `Ok`. If the value is an
-  /// `Err` then it calls `op` with its value.
+  /// Unwraps a result, yielding the content of an [Ok]. If the value is an
+  /// [Err] then it calls `op` with its value.
   Future<T> unwrapOrElse(T Function(E) op) =>
       then((result) => result.unwrapOrElse(op));
 
-  /// Unwraps a result, yielding the content of an `Ok`. If the value is an
-  /// `Err` then it asynchronously calls `op` with its value.
+  /// Unwraps a result, yielding the content of an [Ok]. If the value is an
+  /// [Err] then it asynchronously calls `op` with its value.
   Future<T> unwrapOrElseAsync(Future<T> Function(E) op) =>
       then((result) => result.unwrapOrElseAsync(op));
 }

--- a/lib/src/result_utils/result_option_transposer.dart
+++ b/lib/src/result_utils/result_option_transposer.dart
@@ -2,8 +2,7 @@ part of 'result_utils.dart';
 
 /// Utils for transposing [Result<Option<T>, E>] into [Option<Result<T, E>>]
 /// in a [Future]
-extension ResultOptionTransposer<T extends Object, E extends Object>
-    on Result<Option<T>, E> {
+extension ResultOptionTransposer<T, E extends Object> on Result<Option<T>, E> {
   /// Transposes the result to an option.
   ///
   /// ```dart
@@ -27,7 +26,7 @@ extension ResultOptionTransposer<T extends Object, E extends Object>
 
 /// Utils for transposing [Option<Result<T, E>>] into [Result<Option<T>, E>]
 /// in a [Future]
-extension FutureResultOptionTransposer<T extends Object, E extends Object>
+extension FutureResultOptionTransposer<T, E extends Object>
     on Future<Result<Option<T>, E>> {
   /// Transposes the result to an option.
   ///

--- a/lib/src/result_utils/result_result_flattener.dart
+++ b/lib/src/result_utils/result_result_flattener.dart
@@ -1,7 +1,7 @@
 part of 'result_utils.dart';
 
 /// Utils for flatting [Result<Result<T, E>>]
-extension ResultResultFlattener<T extends Object, E extends Object>
+extension ResultResultFlattener<T, E extends Object>
     on Result<Result<T, E>, E> {
   /// Flattens a [Result<Result<T, E>, E>] into a [Result<T, E>]
   ///
@@ -22,7 +22,7 @@ extension ResultResultFlattener<T extends Object, E extends Object>
 }
 
 /// Utils for flatting [Result<Result<T, E>>] in a [Future]
-extension FutureResultResultFlattener<T extends Object, E extends Object>
+extension FutureResultResultFlattener<T, E extends Object>
     on Future<Result<Result<T, E>, E>> {
   /// Flattens a [Result<Result<T, E>, E>] into a [Result<T, E>]
   ///

--- a/test/result_test.dart
+++ b/test/result_test.dart
@@ -15,6 +15,13 @@ void main() {
       expect(Ok(1).isErr(), isFalse);
     });
 
+    test('ok of null is okay', () {
+      expect(Result.ok(null), isA<Ok>());
+      expect(Ok(null), isA<Ok>());
+      expect(Ok(null).isOk(), isTrue);
+      expect(Ok(null).isErr(), isFalse);
+    });
+
     test('unit value is an ok unit', () {
       final result = Result.ok(unit);
       expect(result, isA<Ok>());
@@ -82,7 +89,7 @@ void main() {
 
       expect(
         Result.err('message').toString(),
-        equals('Err<Object, String>(message)'),
+        equals('Err<dynamic, String>(message)'),
       );
       expect(
         Result<int, String>.err('message').toString(),

--- a/test/src/option/option_to_result_mixin_test.dart
+++ b/test/src/option/option_to_result_mixin_test.dart
@@ -6,8 +6,11 @@ import 'package:test/test.dart';
 void main() {
   test('option as a result', () {
     expect(Option.some(5).okOr(Exception()), isA<Ok>());
+    expect(Option.some(null).okOr(Exception()), isA<Ok>());
     expect(Option.none().okOr(Exception()), isA<Err>());
+
     expect(Option.some(5).okOrElse(() => fail('oh no')), isA<Ok>());
+    expect(Option.some(null).okOrElse(() => fail('oh no')), isA<Ok>());
     expect(Option.none().okOrElse(Exception.new), isA<Err>());
   });
 }

--- a/test/src/option/option_unwrap_mixin_test.dart
+++ b/test/src/option/option_unwrap_mixin_test.dart
@@ -15,6 +15,7 @@ void main() {
   test('unwrapping the present', () {
     expect(() => Option.none().unwrap(), throwsAnOptionUnwrapException);
     expect(Option.some(2).unwrap(), equals(2));
+    expect(Option.some(null).unwrap(), equals(null));
   });
 
   test('unwrapping with a default', () {

--- a/test/src/option_test.dart
+++ b/test/src/option_test.dart
@@ -13,6 +13,11 @@ void main() {
       expect(Some(1), isA<Some>());
     });
 
+    test('some of null has a value', () {
+      expect(Option.some(null), isA<Some>());
+      expect(Some(null), isA<Some>());
+    });
+
     test('none has nothing', () {
       expect(Option.none(), isA<None>());
       expect(None(), isA<None>());


### PR DESCRIPTION
Based on the suggestion from https://github.com/nlfiedler/oxidized/issues/10#issuecomment-1426223594, this PR removes the `extends Object` bound from `Some` and `Ok` so that nullable types are supported as well.

We mainly want to use a `Result<Foo?, Error>` in our project, and `Option<Foo?>` then needs to be allowed as well to not break `result.ok()`. Both changes allow more flexibility in the usage of this package, but developers don't have to work with nullable types if they don't want to.

As described in the linked suggestion, this should be mostly non-breaking. The only difference I could tell is that `Result.err(…)` was previously inferred to `Result<Object, …>` and now becomes `Result<dynamic, …>` and `Option.none()` was previously inferred to `Option<Object>` and now `Option<dynamic>`. Though I'm guessing that their usages usually have better type arguments inferred from their call-site or one isn't interested in the type arguments.